### PR TITLE
Add config to optionally disable HSR interregional travel

### DIFF
--- a/config/params_2005.properties
+++ b/config/params_2005.properties
@@ -153,3 +153,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/config/params_2015.properties
+++ b/config/params_2015.properties
@@ -153,3 +153,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/config/params_2020.properties
+++ b/config/params_2020.properties
@@ -153,3 +153,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/config/params_PBA50_2020.properties
+++ b/config/params_PBA50_2020.properties
@@ -155,3 +155,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/config/params_PBA50_Blueprint2025.properties
+++ b/config/params_PBA50_Blueprint2025.properties
@@ -157,3 +157,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/config/params_PBA50_Blueprint2030.properties
+++ b/config/params_PBA50_Blueprint2030.properties
@@ -157,3 +157,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/config/params_PBA50_Blueprint2035.properties
+++ b/config/params_PBA50_Blueprint2035.properties
@@ -157,3 +157,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = -9999.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/config/params_PBA50_Blueprint2040.properties
+++ b/config/params_PBA50_Blueprint2040.properties
@@ -157,3 +157,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = -9999.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/config/params_PBA50_Blueprint2050.properties
+++ b/config/params_PBA50_Blueprint2050.properties
@@ -154,3 +154,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = -9999.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/config/params_PBA50_BlueprintNoProject2025.properties
+++ b/config/params_PBA50_BlueprintNoProject2025.properties
@@ -156,3 +156,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 1

--- a/config/params_PBA50_BlueprintNoProject2030.properties
+++ b/config/params_PBA50_BlueprintNoProject2030.properties
@@ -156,3 +156,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 1

--- a/config/params_PBA50_BlueprintNoProject2035.properties
+++ b/config/params_PBA50_BlueprintNoProject2035.properties
@@ -156,3 +156,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 1

--- a/config/params_PBA50_BlueprintNoProject2040.properties
+++ b/config/params_PBA50_BlueprintNoProject2040.properties
@@ -157,3 +157,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 1

--- a/config/params_PBA50_BlueprintNoProject2050.properties
+++ b/config/params_PBA50_BlueprintNoProject2050.properties
@@ -154,3 +154,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 1

--- a/config/params_PBA50_EIRalt2_2035.properties
+++ b/config/params_PBA50_EIRalt2_2035.properties
@@ -157,3 +157,9 @@ Means_Based_Fare_Q2Factor  = 0.5
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = -9999.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 1

--- a/config/params_PBA50_EIRalt2_2040.properties
+++ b/config/params_PBA50_EIRalt2_2040.properties
@@ -157,3 +157,9 @@ Means_Based_Fare_Q2Factor  = 0.5
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = -9999.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 1

--- a/config/params_PBA50_EIRalt2_2050.properties
+++ b/config/params_PBA50_EIRalt2_2050.properties
@@ -154,3 +154,9 @@ Means_Based_Fare_Q2Factor  = 0.5
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = -9999.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 1

--- a/config/params_PBA50_IPA2035.properties
+++ b/config/params_PBA50_IPA2035.properties
@@ -156,3 +156,9 @@ Means_Based_Fare_Q2Factor  = 1.0
 # Set to     0.0 to keep on (e.g. free parking eligibility enabled)
 # Set to -9999.0 to turn off (e.g. no free parking)
 Free_Parking_Eligibility_OnOff = 0.0
+
+# HSR inter-regional travel -- flag to disable
+# Introduced in TM1 v0.6, trips to/from HSR stations are from HSR Business Plan (https://github.com/BayAreaMetro/modeling-website/wiki/TravelModelOneV06)
+# Note HSR intraregional travel represented with network project
+# Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable = 0

--- a/model-files/scripts/block/trnParam.block
+++ b/model-files/scripts/block/trnParam.block
@@ -3,3 +3,7 @@
 ; these factors are not used in assignment; they are only used in summarization
 Means_Based_Fare_Q1Factor  = xx.xx     ; a factor between 0 to 1 indicating the fare discount for the lowest income group
 Means_Based_Fare_Q2Factor  = xx.xx     ; a factor between 0 to 1 indicating the are discount for the second lowest income group
+
+; set by RuntimeConfiguration.py -- disable HSR interregional travel
+; Set to 0 to leave trips ON, set to 1 to DISABLE
+HSR_Interregional_Disable  = x

--- a/model-files/scripts/preprocess/HsrTripGeneration.job
+++ b/model-files/scripts/preprocess/HsrTripGeneration.job
@@ -28,6 +28,9 @@
 ; ----------------------------------------------------------------------------------------------------------------
 model_year = %MODEL_YEAR%
 
+; check if HSR_Interregional_Disable is configured
+READ FILE="CTRAMP\scripts\block\trnParam.block"
+
 loop tpnum=1,5
 
   if (tpnum=1)
@@ -51,7 +54,8 @@ loop tpnum=1,5
 
     fileo mato[1] = 'nonres\tripsHsr@time_period@_intermediate.tpp', mo=1-8, name=m_da, m_sr2, m_transit, m_walk, b_da, b_sr2, b_transit, b_walk
 
-    if (@model_year@ < 2035)
+    ; if the model year is before HSR opening OR HSR interregional travel is disabled by configuration
+    if ((@model_year@ < 2035) | (@HSR_Interregional_Disable@=1))
       ; nothing open
       MW[1] = 0
       MW[2] = 0

--- a/model-files/scripts/preprocess/RuntimeConfiguration.py
+++ b/model-files/scripts/preprocess/RuntimeConfiguration.py
@@ -24,7 +24,14 @@ If no iteration is specified, then these include:
    + It will be propagated to CTRAMP\scripts\block\hwyParam.block
  * Telecommute constant
    + It will be propagated to CTRAMP\model\CoordinatedDailyActivityPattern.xls
-
+ * Means Based Tolling (Q1 and Q2) factors
+   + They will be propagated to CTRAMP\scripts\block\hwyParam.block
+                                CTRAMP\runtime\mtcTourBased.properties
+ * Means Based Fare (Q1 and Q2) factors
+   + They will be propagated to CTRAMP\scripts\block\trnParam.block
+                                CTRAMP\runtime\mtcTourBased.properties
+ * HSR Interregional trips disable flag
+   + It will be propagated to CTRAMP\scripts\block\trnParam.block
  * Host IP - where the household manager, matrix manager and JPPF Server run
    + Assumed to be the HOST_IP_ADDRESS in the environment
    + Assumed that this script is running on this host IP (this is verified)
@@ -174,48 +181,7 @@ def config_mobility_params(params_filename, params_contents, for_logsums, replac
 
     Replacements = { filepath -> regex_dict }
     """
-    # get parameters
-    # Mobility.AV.Share = 0.0
-    # Mobility.AV.ProbabilityBoost.AutosLTDrivers = 1.2
-    # Mobility.AV.ProbabilityBoost.AutosGEDrivers = 1.1
-    # Mobility.AV.IVTFactor = 0.5
-    # Mobility.AV.ParkingCostFactor = 0.0
-    # Mobility.AV.CostPerMileFactor = 0.5
-    # Mobility.AV.TerminalTimeFactor = 0.0
-    # Mobility.TNC.shared.IVTFactor = 1.2
-
-    # TNC.single.baseFare = 2.20
-    # TNC.single.costPerMile = 1.33
-    # TNC.single.costPerMinute = 0.24
-    # TNC.single.costMinimum = 7.20
-    #
-    # # use lower costs
-    # TNC.shared.baseFare = 2.20
-    # TNC.shared.costPerMile = 1.33
-    # TNC.shared.costPerMinute = 0.24
-    # TNC.shared.costMinimum = 7.20
-    #
-    # #Note: the following comma-separated value properties cannot have spaces between them, or else the RuntimeConfiguration.py code won't work
-    # TNC.single.waitTime.mean =  10.3,8.5,8.4,6.3,4.7
-    # TNC.single.waitTime.sd =     4.1,4.1,4.1,4.1,4.1
-    #
-    # TNC.shared.waitTime.mean =  15.0,15.0,11.0,8.0,7.0
-    # TNC.shared.waitTime.sd =     4.1,4.1,4.1,4.1,4.1
-    #
-    # Taxi.waitTime.mean = 26.5,17.3,13.3,9.5,5.5
-    # Taxi.waitTime.sd =    6.4,6.4,6.4,6.4,6.4
-    #
-    # Taxi.da.share = 0.0
-    # Taxi.s2.share = 0.9
-    # Taxi.s3.share = 0.1
-    #
-    # TNC.single.da.share = 0.0
-    # TNC.single.s2.share = 0.8
-    # TNC.single.s3.share = 0.2
-    #
-    # TNC.shared.da.share = 0.0
-    # TNC.shared.s2.share = 0.3
-    # TNC.shared.s3.share = 0.7
+    # get parameters - see examples in congig directory
 
     modelYear = int(os.environ["MODEL_YEAR"])
 
@@ -404,6 +370,7 @@ def config_auto_opcost(params_filename, params_contents, for_logsums, replacemen
     MeansBasedTollsQ2Factor  = float(get_property(params_filename, params_contents, "Means_Based_Tolling_Q2Factor"))
     MeansBasedFareQ1Factor   = float(get_property(params_filename, params_contents, "Means_Based_Fare_Q1Factor"))
     MeansBasedFareQ2Factor   = float(get_property(params_filename, params_contents, "Means_Based_Fare_Q2Factor"))
+    HSRInterregionalDisable  =   int(get_property(params_filename, params_contents, "HSR_Interregional_Disable"))
 
     # put the av pce factors into the CTRAMP\scripts\block\hwyParam.block
     filepath = os.path.join("CTRAMP","scripts","block","hwyParam.block")
@@ -428,6 +395,7 @@ def config_auto_opcost(params_filename, params_contents, for_logsums, replacemen
     filepath = os.path.join("CTRAMP","scripts","block","trnParam.block")
     replacements[filepath]["(\nMeans_Based_Fare_Q1Factor[ \t]*=[ \t]*)(\S*)"] = r"\g<1>%.2f" % MeansBasedFareQ1Factor
     replacements[filepath]["(\nMeans_Based_Fare_Q2Factor[ \t]*=[ \t]*)(\S*)"] = r"\g<1>%.2f" % MeansBasedFareQ2Factor
+    replacements[filepath]["(\nHSR_Interregional_Disable[ \t]*=[ \t]*)(\S*)"] = r"\g<1>%d"   % HSRInterregionalDisable
 
 def config_logsums(replacements, append):
     filepath = os.path.join("CTRAMP","runtime","logsums.properties")


### PR DESCRIPTION
The config is updated so that HSR interregional travel is disabled for NoProject and EIR Alt2
Note the config doesn't do anything for model years prior to HSR opening per [ HsrTripGeneration.job ](https://github.com/BayAreaMetro/travel-model-one/blob/master/model-files/scripts/preprocess/HsrTripGeneration.job)