### PR TITLE
add option to use modeled air-basin VMT split for EMFAC vmt summarization

### DIFF
--- a/model-files/RunPrepareEmfac.bat
+++ b/model-files/RunPrepareEmfac.bat
@@ -116,13 +116,19 @@ if %1==EIR (
 echo emfacVersion=%emfacVersion%
 
 :: run the emfac prep script with arguments related to how we'll run emfac
-python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac %emfacVersion% --run_mode emissions --sub_area MPO-MTC --season annual --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions
+python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac %emfacVersion% --run_mode emissions --sub_area MPO-MTC --season annual --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions --airbasin_split_method EMFAC-airbasin-default
+:: altertively, if we want to use modeled air basin VMT split rather than EMFAC-default split to summarize VMT, use the following command instead:
+:: python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac %emfacVersion% --run_mode emissions --sub_area MPO-MTC --season annual --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions --airbasin_split_method modeled-airbasin-split
 
 :: for EIR, also run SEASON=winter and EMFAC2021
 if %1==EIR (
-  python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac %emfacVersion% --run_mode emissions --sub_area MPO-MTC --season winter --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions
-  python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac 2021 --run_mode emissions --sub_area MPO-MTC --season winter --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions
-  python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac 2021 --run_mode emissions --sub_area MPO-MTC --season annual --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions
+  python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac %emfacVersion% --run_mode emissions --sub_area MPO-MTC --season winter --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions --airbasin_split_method EMFAC-airbasin-default
+
+  python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac 2021 --run_mode emissions --sub_area MPO-MTC --season winter --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions --airbasin_split_method EMFAC-airbasin-default
+  python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac 2021 --run_mode emissions --sub_area MPO-MTC --season annual --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions --airbasin_split_method EMFAC-airbasin-default
+  :: alternatively, if we want to use modeled air basin VMT split rather than EMFAC-default split to summarize VMT, use the following command instead:
+  :: python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac 2021 --run_mode emissions --sub_area MPO-MTC --season winter --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions --airbasin_split_method modeled-airbasin-split
+  :: python %EMFAC_SCRIPT_DIR%\create_EMFAC_custom_activity_file.py --analysis_type %1 --emfac 2021 --run_mode emissions --sub_area MPO-MTC --season annual --VMT_data_type totalDailyVMT --custom_hourly_speed_fractions --airbasin_split_method modeled-airbasin-split
 )
 
 :end

--- a/model-files/scripts/emfac/BetweenZonesVMT.py
+++ b/model-files/scripts/emfac/BetweenZonesVMT.py
@@ -19,10 +19,24 @@ from os import path
 # -------------------------------------------------------------------
 # loaded network assignment file
 loadednet_df = pd.read_csv(os.path.join(os.getcwd(), "hwy", "iter3", "avgload5period_vehclasses.csv"), index_col=False, sep=",")
+# print(loadednet_df.head())
+# loaded network link to air basin crosswalk file
+link_airbasin_crowwalk = pd.read_csv(os.path.join(os.getcwd(), "hwy", "link_to_airbasin.csv"), index_col=False, sep=",")
+# print(link_airbasin_crowwalk.head())
+
+# validate that the two files have the same number of unique links
+if loadednet_df.shape[0] != link_airbasin_crowwalk[['A', 'B']].drop_duplicates().shape[0]:
+   raise ValueError(
+      "Loaded network and air basin crosswalk have different numbers of unique (A,B) links: "
+      f"loadednet={loadednet_df.shape[0]}, crosswalk={link_airbasin_crowwalk[['A', 'B']].drop_duplicates().shape[0]}."
+   )
+
 
 # Todo: add truck or no truck
 
 output_csv = "emfac\\emfac_prep\\CreateSpeedBinsBetweenZones_sums.csv"
+debug_csv = "emfac\\emfac_prep\\betweenZone_airBasin_split_debug.csv"
+vmt_by_airbasin_csv = "emfac\\emfac_prep\\VMT_betweenZones_airBasin.csv"
 
 
 # -------------------------------------------------------------------
@@ -50,6 +64,12 @@ loadednet_df['countyName'] = np.select(GL_conditions, CountyName_choices , defau
 arbCounty_choices = ["38", "41", "43", "01", "07", "48", "28", "49", "21", "9999"]
 loadednet_df[' arbCounty'] = np.select(GL_conditions, arbCounty_choices , default='null')
 
+# join the crosswalk to the loaded network dataframe. Note that the crosswalk may have multiple rows for the same (A,B) link
+loadednet_df = pd.merge(
+   loadednet_df,
+   link_airbasin_crowwalk.rename(columns={'A': 'a', 'B': 'b'}),
+   on=['a', 'b'], how='right', validate='1:m')
+
 # create dataframe for each time period and loop through tem
 # store dataframes into a dictionary
 timeperiodList = ['EA', 'AM', 'MD', 'PM', 'EV']
@@ -73,17 +93,28 @@ for tp in timeperiodList:
         (loadednet_df['cspd'+tp] >= 55) & (loadednet_df['cspd'+tp] < 60),
         (loadednet_df['cspd'+tp] >= 60)]
     SpeedBin_choices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-    loadednet_df[' speedBin'] = np.select(Speed_conditions, SpeedBin_choices, default='null')
+    loadednet_df[' speedBin'] = np.select(Speed_conditions, SpeedBin_choices, default=np.nan)
 
     # reset speeds to 25 mph for dummy links (these are dummy/centroid connector-access links)
     loadednet_df[' speedBin'] = np.where(loadednet_df['ft']==6, 6, loadednet_df[' speedBin']).astype(int)
 
     # calculate vmt
-    loadednet_df['vmt_'+tp] = loadednet_df['distance'] *  loadednet_df['vol'+tp+'_tot']
+    loadednet_df['vmt_temp'+tp] = loadednet_df['distance'] *  loadednet_df['vol'+tp+'_tot']
+    # for links that are split across multiple air basins, vmt should be proportional to the share of link distance, represented by 'linktaz_share'
+    loadednet_df['vmt_'+tp] = loadednet_df['vmt_temp'+tp] * loadednet_df['linktaz_share']
+
+   #  print(loadednet_df.loc[loadednet_df[['a','b']].duplicated(keep=False)].sort_values(['a','b'])[[
+   #     'countyName', ' arbCounty', 'ctAirBasin','link_mi','linktaz_mi','merge_type','linktaz_share',' speedBin', 'vmt_'+tp, 'vmt_temp'+tp]].head())
+    # export for debugging
+    loadednet_df[['a', 'b','countyName', ' arbCounty', 'ctAirBasin', ' speedBin', 'merge_type', 'linktaz_share','vmt_'+tp, 'vmt_temp'+tp]].to_csv(
+       debug_csv, header=True, index=False)
 
     # keep the relevant columns
+    # Note that here, we only use countyName and arbCounty, not AirBasin, to maintain the same structure as WithinZone summary.
+      # The AirBasin split will be done later, and only used to adjust total VMT split by air basin for Solano/Sonoma counties,
+      # in the downstream step create_EMFAC_custom_activity_file.py. The AirBasin split is not used for the more granular
+      # VMT by speed bin and hour, which is the main output of this script.
     loadednet1_df =  loadednet_df[['countyName', ' arbCounty', ' speedBin', 'vmt_'+tp]]
-
     # save as new dataframe
     key_name = 'VMTBySpeedBin_'+ tp +'_df'
     key_name = loadednet1_df.groupby(['countyName', ' arbCounty', ' speedBin'], as_index=False).sum()
@@ -92,6 +123,14 @@ for tp in timeperiodList:
     if tp=='EA':
         VMTBySpeedBin_allTP_df = key_name
     else: VMTBySpeedBin_allTP_df = pd.merge(VMTBySpeedBin_allTP_df, key_name, left_on=['countyName', ' arbCounty', ' speedBin'], right_on=['countyName', ' arbCounty', ' speedBin'], how='outer')
+
+    # summarize by airbasin
+    loadednet2_df = loadednet_df[['ctAirBasin', ' speedBin', 'vmt_'+tp]]
+    key_name2 = loadednet2_df.groupby(['ctAirBasin', ' speedBin'], as_index=False).sum()
+    # merge the data frames
+    if tp=='EA':
+        VMTBySpeedBin_allTP_airBasin_df = key_name2
+    else: VMTBySpeedBin_allTP_airBasin_df = pd.merge(VMTBySpeedBin_allTP_airBasin_df, key_name2, on=['ctAirBasin', ' speedBin'], how='outer')
 
 # set within time period diurnal factor consistent with EMFAC
 # (these diurnal factors came from the old script CreateSpeedBinsBetweenZones.job)
@@ -184,3 +223,9 @@ VMTBySpeedBin_allTP_df.sort_values(by=['countyName', ' speedBin'], inplace=True)
 VMTBySpeedBin_allTP_df.fillna(0, inplace=True)
 
 VMTBySpeedBin_allTP_df.to_csv(output_csv, header=True, index=False)
+
+# vmt by airbasin
+for i in ['vmt_EA', 'vmt_AM', 'vmt_MD', 'vmt_PM', 'vmt_EV']:
+   VMTBySpeedBin_allTP_airBasin_df[i] = VMTBySpeedBin_allTP_airBasin_df[i].fillna(0)
+VMTBySpeedBin_allTP_airBasin_df['dailyVMT_airBasin'] = VMTBySpeedBin_allTP_airBasin_df[['vmt_EA', 'vmt_AM', 'vmt_MD', 'vmt_PM', 'vmt_EV']].sum(axis=1)
+VMTBySpeedBin_allTP_airBasin_df.to_csv(vmt_by_airbasin_csv, header=True, index=False)

--- a/model-files/scripts/emfac/create_EMFAC_custom_activity_file.py
+++ b/model-files/scripts/emfac/create_EMFAC_custom_activity_file.py
@@ -151,6 +151,7 @@ if __name__ == '__main__':
     parser.add_argument("--VMT_data_type",                 required=True, choices=['totalDailyVMT','VMTbyVehFuelType'])
     parser.add_argument("--custom_hourly_speed_fractions", action='store_true', help="For 'Custom Hourly Speed Fractions' checkbox")
     parser.add_argument("--file_suffix", default="", help="Optional suffix for output folders/files; to QA/compare against manually created versions")
+    parser.add_argument("--airbasin_split_method",         required=True, choices=['EMFAC-airbasin-default','modeled-airbasin-split'], help="Choose method to split VMT by Air Basin for Solano and Sonoma")
 
     args = parser.parse_args()
 
@@ -173,11 +174,11 @@ if __name__ == '__main__':
     input_custom_activity_template_fullpath = pathlib.Path(__file__).parent / "Custom_Activity_Templates" / input_custom_activity_template
 
     # ================= Output custom activity file is based on Harold's convention =================
-    output_custom_activity_file = f"E{args.emfac_version}_{MODEL_RUN_ID}_{args.season}{args.file_suffix}.xlsx"
+    output_custom_activity_file = f"E{args.emfac_version}_{MODEL_RUN_ID}_{args.season}{args.file_suffix}_{args.airbasin_split_method}.xlsx"
     # and it's local
     output_custom_activity_dir = CWD_OUTPUT / "emfac" / args.analysis_type / f"E{args.emfac_version}{args.file_suffix}"
     # create it since log file will go there
-    output_custom_activity_dir.mkdir(parents=True, exist_ok=True)
+    # output_custom_activity_dir.mkdir(parents=True, exist_ok=True)
     output_custom_activity_file_fullpath = output_custom_activity_dir / output_custom_activity_file
     log_file_full_path = output_custom_activity_dir / output_custom_activity_file.replace(".xlsx",".log")
 
@@ -378,7 +379,7 @@ if __name__ == '__main__':
         # The rows are subarea (11) x hour (24) x Veh_Tech (51-55)
         # The columns are the 18 speed bins, plus index columns (Sub-Area, GAI, Sub-Area, Cal_Year, Veh_Tech, Hour)
 
-        # merge DataFrames
+        # merge DataFrames - resulting DataFrame has both the default and modeled VMT fractions (by speed bin, for each hour)
         TM_HourlyFraction_df = pd.merge(
             left     = DefaultHourlyFraction_df, 
             right    = VMT_df[['GAI','hour'] + 
@@ -455,10 +456,11 @@ if __name__ == '__main__':
     ModelledVMTbyGAI_df = VMT_df[['countyName','GAI','AirBasin','HourlyTotalVMT']].groupby(
         ['countyName','GAI','AirBasin'], as_index=False).sum()
     logging.debug("ModelledVMTbyGAI_df:\n{}".format(ModelledVMTbyGAI_df))
-    # Note: the Solano/Sonoma VMT by GAI isn't accurate - it's duplicated
-    # So need to apportion it based on the DefaultVMT split
+    # Note: the modeled Solano/Sonoma VMT by GAI isn't accurate - it's duplicated; need to apportion it based on the VMT split between air basins
+        # method 1: apportion it based on the DefaultVMT split
+        # method 2: apportion it based on the modeled VMT split (based on link to air basin crosswalk)
 
-    # merge modelled VMT and default VMT by GAI; modeled is called 'HourlyTotalVMT'
+    # for method 1: merge modelled VMT and default VMT by GAI; modeled is called 'HourlyTotalVMT'
     VMTbyGAI_df = pd.merge(
         left    = DefaultVMTbyGAI_df, 
         right   = ModelledVMTbyGAI_df, 
@@ -476,10 +478,50 @@ if __name__ == '__main__':
         how     = 'left'
     )
     logging.debug("VMTbyGAI_df:\n{}".format(VMTbyGAI_df))
-    # columns are now: Sub-Area, GAI, DefaultVMT_GAI, countyName, AirBasin, HourlyTotalVMT (modeled), DefaultVMT_county
-    # apportion based on share DefaultVMT for GAI / DefaultVMT for County
-    VMTbyGAI_df['HourlyTotalVMT'] = VMTbyGAI_df.HourlyTotalVMT * (VMTbyGAI_df.DefaultVMT_GAI/VMTbyGAI_df.DefaultVMT_county)
-    logging.debug("VMTbyGAI_df after apportioning county by GAI:\n{}".format(VMTbyGAI_df))
+
+    # for method 2: also merge in the modeled Sub-Area VMT summary from the vmt_by_airbasin_df
+    vmt_by_airbasin_df = pd.read_csv(EMFAC_PREP / "VMT_betwweenZones_airBasin.csv")
+    logging.debug("vmt_by_airbasin_df.head():\n{}".format(vmt_by_airbasin_df.head()))
+    # make the air basin column match the one in COUNTY_GAI_AIRBASIN_DF
+    vmt_by_airbasin_df[['county_temp', 'AirBasin_temp']] = vmt_by_airbasin_df['ctAirBasin'].str.split('_', expand=True)
+    vmt_by_airbasin_df['Sub-Area_modeled'] = \
+        vmt_by_airbasin_df['county_temp'] + ' (' + vmt_by_airbasin_df['AirBasin_temp'] + ')'
+    vmt_by_airbasin_summary_df = vmt_by_airbasin_df.groupby(['county_temp', 'Sub-Area_modeled'], as_index=False)[['dailyVMT_airBasin']].sum()
+
+    VMTbyGAI_df = pd.merge(
+        left    = VMTbyGAI_df,
+        right   = vmt_by_airbasin_summary_df,
+        left_on = ['Sub-Area'],
+        right_on= ['Sub-Area_modeled'],
+        how     = 'left'
+    )
+    VMTbyCounty_fromAirBasin_df = VMTbyGAI_df.groupby(['county_temp'], as_index=False)[['dailyVMT_airBasin']].sum()
+    VMTbyCounty_fromAirBasin_df.rename(columns={'dailyVMT_airBasin':'VMT_county_airBasin'}, inplace=True)
+    VMTbyGAI_df = pd.merge(
+        left    = VMTbyGAI_df,
+        right   = VMTbyCounty_fromAirBasin_df,
+        left_on = ['county_temp'],
+        right_on= ['county_temp'],
+        how     = 'left'
+    )
+    logging.debug("VMTbyGAI_df with EMFAC Default and Modelled:\n{}".format(VMTbyGAI_df))
+    # VMTbyGAI_df.to_csv(EMFAC_PREP / "VMTbyGAI_df_debug.csv", header=True, index=False)
+
+    # columns are now: 
+     # from EMFAC default:                          Sub-Area, GAI, DefaultVMT_GAI, DefaultVMT_county
+     # from modeled BetweenZones and WithinZone:    countyName, AirBasin, HourlyTotalVMT (modeled)
+     # from modeled vmt by airBasin summary:        Sub-Area_modeled, dailyVMT_airBasin, VMT_county_airBasin
+    
+    if args.airbasin_split_method == 'EMFAC-airbasin-default':
+        logging.info("Using EMFAC default method to split VMT by Air Basin for Solano and Sonoma")
+        # method 1: apportion based on share DefaultVMT for GAI / DefaultVMT for County
+        VMTbyGAI_df['HourlyTotalVMT'] = VMTbyGAI_df.HourlyTotalVMT * (VMTbyGAI_df.DefaultVMT_GAI/VMTbyGAI_df.DefaultVMT_county)
+        logging.debug("VMTbyGAI_df after apportioning county by GAI:\n{}".format(VMTbyGAI_df))
+
+    # method 2: apportion based on share of modeled VMT for Sub-Area / modeled VMT for County
+    elif args.airbasin_split_method == 'modeled-airbasin-split':
+        logging.info("Using modeled method to split VMT by Air Basin for Solano and Sonoma")
+        VMTbyGAI_df['HourlyTotalVMT'] = VMTbyGAI_df.HourlyTotalVMT * (VMTbyGAI_df.dailyVMT_airBasin/VMTbyGAI_df.VMT_county_airBasin)
 
     # This section is for args.VMT_data_type=='VMTbyVehFuelType'
     # But for args.VMT_data_type=='totalDailyVMT', it doesn't actually do anything (percentVMT will be 1.0)
@@ -488,7 +530,7 @@ if __name__ == '__main__':
     # Merge current VMT totals back into the original default VMT dataframe
     DefaultVMT_detail_df = pd.merge(
         left    = DefaultVMT_df,
-        right   = VMTbyGAI_df.drop(columns=['DefaultVMT_county']), 
+        right   = VMTbyGAI_df.drop(columns=['DefaultVMT_county','VMT_county_airBasin']), 
         on      = ['Sub-Area','GAI'],
         how     = 'left'
     )

--- a/utilities/RTP/config_RTP2025/SetUpModel_PBA50Plus.bat
+++ b/utilities/RTP/config_RTP2025/SetUpModel_PBA50Plus.bat
@@ -119,6 +119,7 @@ if "%COMPUTER_PREFIX%" == "WIN-"    set HOST_IP_ADDRESS=10.0.0.59
 :: networks
 c:\windows\system32\Robocopy.exe /NP /E "%INPUT_NETWORK%\hwy"                                        INPUT\hwy
 c:\windows\system32\Robocopy.exe /NP /E "%INPUT_NETWORK%\trn"                                        INPUT\trn
+copy /Y "%INPUT_NETWORK%\shapefiles\link_to_airbasin.csv"                                            INPUT\hwy\link_to_airbasin.csv
 
 :: popsyn and land use
 c:\windows\system32\Robocopy.exe /NP /E "%INPUT_POPLU%\popsyn"                                       INPUT\popsyn

--- a/utilities/cube-to-shapefile/cube_to_shapefile.py
+++ b/utilities/cube-to-shapefile/cube_to_shapefile.py
@@ -81,6 +81,11 @@ If --transit_crowding is specified, then the complete transit crowding file is r
    4) network_trn_stops.shp - this has per stop information, including LINE_NAME, STATION, N, SEQ, IS_STOP.
       If --loadvol_dr is specified, then boardings (BRD) and exits (XIT) as given per time period.
 
+ If --LINK_TAGGING_SHAPE, --LINK_TAGGING_ID_FIELD, --LINK_TAGGING_OUTPUT are specified, then a link to shape crosswalk will be created by running
+   utilities/geographies/create_geography_overlays/correspond_link_to_TAZ.py (called by the tag_links_with_geography function)
+   A link to air basin crosswalk is created by default; the crosswalk will be required in RunPrepareEmfac.bat if the user choose to use modeled air basin VMT split
+    rather than EMFAC-default split to summarize VMT. See \model-files\scripts\emfac\create_EMFAC_custom_activity_file.py for details.
+    
 """
 
 import argparse, collections, copy, csv, logging, os, pathlib, re, subprocess, sys, traceback
@@ -104,6 +109,8 @@ TRN_STOPS_SHPFILE = "network_trn_stops{}.shp"
 TRN_ROUTE_LINKS_SHPFILE = "network_trn_route_links.shp"
 
 COUNTY_SHPFILE = pathlib.Path("X:/travel-model-one-master/utilities/geographies/region_county.shp")
+LINK_TAGGING_SHAPEFILE = pathlib.Path("M:/Data/GIS layers/ca_air_basins/bay_area_county_air_basin.shp")
+LINK_TAGGING_CSV = pathlib.Path("link_to_airbasin.csv")
 
 # TODO: Use an effective duration for EA and EV?
 TIMEPERIOD_DURATIONS = collections.OrderedDict([
@@ -224,6 +231,53 @@ def runCubeScript(workingdir, script_filename, script_env):
     if retcode == 2:
         raise Exception(f"Failed to run Cube script {script_filename}")
     logger.info(f"  Received {retcode} from 'runtpp {script_filename}'")
+
+
+def tag_links_with_geography(
+    workingdir: pathlib.Path,
+    link_shapefile: pathlib.Path,
+    output_csv: pathlib.Path,
+    geography_shapefile: pathlib.Path,
+    shp_id: str,
+):
+    """Tag roadway links to a geography shapefile and write link-level correspondence CSV."""
+    logger = logging.getLogger()
+    tag_script = pathlib.Path(__file__).resolve().parents[1] / "geographies" / "create_geography_overlays" / "correspond_link_to_TAZ.py"
+
+    if not tag_script.exists():
+        raise FileNotFoundError(f"Link tagging script not found: {tag_script}")
+    if not geography_shapefile.exists():
+        raise FileNotFoundError(f"Link tagging shapefile not found: {geography_shapefile}")
+
+    cmd = [
+        sys.executable,
+        str(tag_script),
+        str(link_shapefile),
+        str(output_csv),
+        "--shapefile",
+        str(geography_shapefile),
+        "--shp_id",
+        shp_id,
+    ]
+    logger.info("Running link tagging step")
+    logger.info(f"  command: {' '.join(cmd)}")
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=workingdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    for line in proc.stdout:
+        logger.info(f"  tagging stdout: {line.rstrip()}")
+    for line in proc.stderr:
+        logger.info(f"  tagging stderr: {line.rstrip()}")
+
+    retcode = proc.wait()
+    if retcode != 0:
+        raise RuntimeError(f"Link tagging step failed with return code {retcode}")
+    logger.info(f"Wrote link tagging CSV to {output_csv}")
 
 
 def get_name_set(line_name, mode_type):
@@ -963,6 +1017,9 @@ if __name__ == '__main__':
     parser.add_argument("--by_operator", action="store_true", help="Split transit lines by operator")
     parser.add_argument("--loadvol_dir", help="Directory with loaded volume files for joining")
     parser.add_argument("--transit_crowding", help="Transit crowding link file for joining. If this argument is specified, then specifying a loadvol_dir is also required.")
+    parser.add_argument("--link_tagging_csv", default=str(LINK_TAGGING_CSV), help="Output link tagging CSV filename")
+    parser.add_argument("--link_tagging_shapefile", default=str(LINK_TAGGING_SHAPEFILE), help="Geography shapefile used for link tagging")
+    parser.add_argument("--link_tagging_id_field", default="ctAirBasin", help="ID field in link tagging shapefile")
     args = parser.parse_args()
     # print(args)
 
@@ -970,6 +1027,9 @@ if __name__ == '__main__':
     LINE_FILE             = pathlib.Path(args.linefile) if args.linefile else None
     LOADVOL_DIR           = pathlib.Path(args.loadvol_dir) if args.loadvol_dir else None
     TRANSIT_CROWDING_FILE = pathlib.Path(args.transit_crowding) if args.transit_crowding else None
+    LINK_TAGGING_SHAPE    = pathlib.Path(args.link_tagging_shapefile) if args.link_tagging_shapefile else None
+    LINK_TAGGING_ID_FIELD = args.link_tagging_id_field if args.link_tagging_id_field else None
+    LINK_TAGGING_OUTPUT   = pathlib.Path(args.link_tagging_csv) if args.link_tagging_csv else None
 
     if TRANSIT_CROWDING_FILE and not LOADVOL_DIR:
         print(USAGE)
@@ -987,6 +1047,9 @@ if __name__ == '__main__':
             LOADVOL_DIR = LOADVOL_DIR.absolute()
         if TRANSIT_CROWDING_FILE:
             TRANSIT_CROWDING_FILE = TRANSIT_CROWDING_FILE.absolute()
+        if LINK_TAGGING_SHAPE:
+            LINK_TAGGING_SHAPE = LINK_TAGGING_SHAPE.absolute()
+            LINK_TAGGING_OUTPUT = LINK_TAGGING_OUTPUT.absolute()
 
         os.chdir( WORKING_DIR )
     else:
@@ -1014,4 +1077,12 @@ if __name__ == '__main__':
         TRANSIT_CROWDING_FILE,
         WORKING_DIR,
         args.by_operator,
+    )
+
+    tag_links_with_geography(
+        workingdir=WORKING_DIR,
+        link_shapefile=pathlib.Path(LINK_SHPFILE),
+        output_csv=LINK_TAGGING_OUTPUT,
+        geography_shapefile=LINK_TAGGING_SHAPE,
+        shp_id=LINK_TAGGING_ID_FIELD,
     )


### PR DESCRIPTION
### Goal
When preparing VMT data for EMFAC run, VMT needs to be summarized by County and Air Basin - Solano and Sonoma counties each covers two Air Basins.

- Previously, network links are only tagged by County ("GL"), not Air Basin, therefore, County-level VMT is summarized from the loaded network, then the default VMT split by Air Basin in EMFAC is used to apportion county-level VMT to Air Basin level for the two counties. 

- Added an option to either use EMFAC default or modeled VMT split by Air Basin to apportion the county-level VMT.

### Changes
Involves multiple steps:
- (one-time step): a County - Air Basin shapefile that will be used to generate link - Air Basin crosswalk
- (when creating input network): new step in cube_to_shapefile to create the link - Air Basin crosswalk
- (during SetUpModel.bat): copy the link - Air Basin crosswalk along with other network inputs
- (when setting up a model run): config RunPrepareEmfac.bat to specify the split method

### Caveats

1. The link-Air Basin crosswalk generated from this process has minor inconsistency with the native "GL" field of the loaded network. One common reason is link crossing county boundaries; another reason is slight boundary misalignments between different spatial data (which is quite common). For example, the following two links (731-3978 and 20087-9870) are both tagged by multiple County-Air Basins despite having one "GL" in the loaded network. The "linktaz_share" shows that the links are mostly within one county. ("linktaz_share" is effectively "linkshare_airBasin" here; it is just a legacy name from the tagging method)

A | B | GL | CountyName | DISTANCE | geometry | ctAirBasin | link_mi | linktaz_mi | merge_type | linktaz_share | countyName | AirBasin
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
731 | 3978 | 4 | Alameda | 0.51656 | LINESTRING (595588.5 4175772.784, 596035 4176474) | Alameda_SF | 0.157444 | 0.156007 | intersect | 0.990872 | Alameda | SF
731 | 3978 | 4 | Alameda | 0.51656 | LINESTRING (595588.5 4175772.784, 596035 4176474) | Contra Costa_SF | 0.157444 | 0.001437 | intersect | 0.009128 | Contra Costa | SF
20087 | 9870 | 2 | San Mateo | 0.64000 | LINESTRING (577223.688 4145503.523, 576391.688... | San Mateo_SF | 0.201792 | 0.194021 | intersect | 0.961493 | San Mateo | SF
20087 | 9870 | 2 | San Mateo | 0.64000 | LINESTRING (577223.688 4145503.523, 576391.688... | Santa Clara_SF | 0.201792 | 0.007770 | intersect | 0.038507 | Santa Clara | SF

2. The link-Air Basin crosswalk assigns every link one or more Bay Area counties and Air Basins, different from the native "GL" field which has "GL == 10" ("external") for some links. This is because [correspond_link_to_TAZ.py](https://github.com/BayAreaMetro/travel-model-one/blob/a1c6cfb48ed3397a436170d810db91c5f9474c08/utilities/geographies/create_geography_overlays/correspond_link_to_TAZ.py#L10) finds the "nearest" shape for links falling outside of the region. It is possible to include non-Bay Area Air Basin shapes in the tagging step, but it creates messy tagging results around the region's boundary due to the previously mentioned geometry misalignment issue. 

3. The link-AirBasin crosswalk is only use to summarize betweenZone VMT. 

4. Due to 2 and 3, when summarizing modeled VMT by hour and by speed bin in create_EMFAC_custom_activity_file.py, as well as calculation VMT Hourly Fractions by speed bin, the original data and method are retained - using "GL" field, including both betweenZone and withinZone VMT, and exclude VMT from "external" links. 

5. Due to 2 and 3, when apportion the county-level modeled VMT by Air Basin for Solano and Sonoma, if "modeled-airbasin-split" is selected, the VMT split reflects all network links including "external" links, but without "betweenZone" VMT.  In other words, using this split assumes that "external" links have the same Ais Basin VMT split as internal links, and withinZone VMT has the same Air Basin split as betweenZone VMT. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214784392225629