### PR TITLE
Phase 3: calibration reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ TM1_RUNS_ROOT=E:/runs
 # creates the output files, empty -- so the step verifies them and fails there.
 TM1_GAWK_DIR=C:/Program Files/Git/usr/bin
 
+# Processed BATS survey output -- the observed side of the calibration report.
+TM1_SURVEY_DIR=//models.ad.mtc.ca.gov/data/models/Application/Model One/Survey
+
 # --- optional ----------------------------------------------------------------
 
 # The three Cube files this needs.  Shown here are the installer defaults, already

--- a/projects/ctramp_2023/config.yaml
+++ b/projects/ctramp_2023/config.yaml
@@ -15,6 +15,10 @@ logging:
 # ROOT is machine-specific -- which network and which land use are spelled out below.
 m_drive: "{env:TM1_M_DRIVE}"        # M: = \\models.ad.mtc.ca.gov\data\models
 
+# Observed data the calibration report compares against -- the BATS survey processed
+# into CT-RAMP's own output format, so one reader serves both sides of the comparison.
+survey_dir: "{env:TM1_SURVEY_DIR}"
+
 # Injected per run -- usable below, not settable:
 #   run_dir = {env:TM1_RUNS_ROOT}/{project}/{case}-{NNN}, plus runs_root, project, case, run
 # {PERIOD} and {iteration} are expanded per step.
@@ -448,6 +452,63 @@ steps:
       job: "CTRAMP/scripts/database/SkimsDatabase.job"
   - net2csv_avgload5period:
       job: "CTRAMP/scripts/metrics/net2csv_avgload5period.job"
+
+  # Calibration: an HTML report putting the survey and this run's CT-RAMP output side
+  # by side, submodel by submodel.  Reads the CSVs CT-RAMP wrote to main/, so it runs
+  # after the loop; `write_csv: true` also drops the underlying tables.
+  - calibration:
+      output_dir: "{run_dir}/calibration_output"
+      write_csv: false
+
+      datasets:
+        - label: "BATS_2023"
+          format: ctramp
+          weight_col:
+            wsloc_results: "person_weight"
+            cdap_results: "person_weight"
+            households: "hh_weight"
+            ao_results: "hh_weight"
+            indiv_tour_data: "tour_weight"
+            joint_tour_data: "tour_weight"
+            indiv_trip_data: "trip_weight"
+            joint_trip_data: "trip_weight"
+          paths:
+            households: "{survey_dir}/ctramp_2023/HouseholdData.csv"
+            persons: "{survey_dir}/ctramp_2023/PersonData.csv"
+            wsloc_results: "{survey_dir}/ctramp_2023/MandatoryLocationData.csv"
+            taz_data: "{run_dir}/landuse/tazData.csv"
+            dist_skim: "{run_dir}/skims/nonmotskm.tpp"
+            cdap_results: "{survey_dir}/ctramp_2023/cdapResults.csv"
+            ao_results: "{survey_dir}/ctramp_2023/aoResults.csv"
+            indiv_tour_data: "{survey_dir}/ctramp_2023/IndivTourData.csv"
+            indiv_trip_data: "{survey_dir}/ctramp_2023/IndivTripData.csv"
+            joint_tour_data: "{survey_dir}/ctramp_2023/JointTourData.csv"
+            joint_trip_data: "{survey_dir}/ctramp_2023/JointTripData.csv"
+
+        # This run.  `sampleshare` scales it up to the survey's population; the `_3`
+        # suffix names the last global round, so it tracks `iterate: count:` above.
+        - label: "CTRAMP"
+          format: ctramp
+          sampleshare: 0.5
+          paths:
+            taz_data: "{run_dir}/landuse/tazData.csv"
+            dist_skim: "{run_dir}/skims/nonmotskm.tpp"
+            households: "{run_dir}/popsyn/hhFile.csv"
+            wsloc_results: "{run_dir}/main/wsLocResults_3.csv"
+            ao_results: "{run_dir}/main/aoResults.csv"
+            cdap_results: "{run_dir}/main/cdapResults.csv"
+            indiv_tour_data: "{run_dir}/main/indivTourData_3.csv"
+            joint_tour_data: "{run_dir}/main/jointTourData_3.csv"
+            indiv_trip_data: "{run_dir}/main/indivTripData_3.csv"
+            joint_trip_data: "{run_dir}/main/jointTripData_3.csv"
+
+      submodels:
+        - work_school_location
+        - auto_ownership
+        - daily_activity_pattern
+        - nonwork_dest_choice
+        - tour_mode_choice
+        - trip_mode_choice
 
   # Python-native, unlike every step above: `script:` imports and calls with the resolved
   # config rather than spawning a subprocess.  This is the shape #110 converts the legacy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,10 @@ dependencies = [
     "numpy>=1.26",
     "openmatrix>=0.3.5",
     "pandas>=2.0",
+    "plotly>=6.7.0",
+    "polars>=1.39.3",
     "psutil>=5.9",
+    "pydantic>=2.0",
     "python-dotenv>=1.0",
     "pyyaml>=6.0",
     "requests>=2.31",
@@ -48,7 +51,6 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "polars>=1.39.3",  # golden-fixture comparison in tests
     "pytest>=9.0.3",
     "pytest-coverage>=0.0",
     "ruff>=0.15.11",

--- a/src/tm1/steps/__init__.py
+++ b/src/tm1/steps/__init__.py
@@ -30,6 +30,7 @@ import tm1.steps.external as external_step
 import tm1.steps.setup as setup_step
 import tm1.steps.simulate_ctramp as simulate_ctramp_step
 import tm1.steps.staging as staging_step
+import tm1.steps.summaries.calibration as calibration_step
 
 log = logging.getLogger(__name__)
 
@@ -50,6 +51,8 @@ STEPS: dict[str, Callable] = {
     "configure_ctramp": configure_ctramp_step.run,
     "simulate_ctramp": simulate_ctramp_step.run,
     "assignment": assignment_step.run,
+    # Reporting.
+    "calibration": calibration_step.run,
 }
 
 DEFAULT_STEPS = list(STEPS.keys())

--- a/src/tm1/steps/summaries/__init__.py
+++ b/src/tm1/steps/summaries/__init__.py
@@ -1,0 +1,1 @@
+"""Summary runners for post-simulation analysis."""

--- a/src/tm1/steps/summaries/calibration/__init__.py
+++ b/src/tm1/steps/summaries/calibration/__init__.py
@@ -1,0 +1,265 @@
+"""Calibration summaries for travel model submodels."""
+
+import logging
+import time
+from pathlib import Path
+from types import ModuleType
+
+import polars as pl
+
+from .bundle import ModelBundle
+from .compare import build_comparison, write_comparison_csvs
+from .config import parse_config
+from .io import load_bundle
+from .report import write_report
+from .submodels import (
+    atwork_subtour,
+    auto_ownership,
+    daily_activity_pattern,
+    nonwork_dest_choice,
+    tour_mode_choice,
+    trip_mode_choice,
+    work_from_home,
+    work_school_location,
+)
+
+log = logging.getLogger(__name__)
+
+# Maps submodel name → (module, required bundle fields)
+SUBMODELS: dict[str, ModuleType] = {
+    "work_school_location": work_school_location,
+    "auto_ownership": auto_ownership,
+    "work_from_home": work_from_home,
+    "daily_activity_pattern": daily_activity_pattern,
+    "nonwork_dest_choice": nonwork_dest_choice,
+    "tour_mode_choice": tour_mode_choice,
+    "atwork_subtour": atwork_subtour,
+    "trip_mode_choice": trip_mode_choice,
+}
+
+
+def _check_bundle_inputs(bundle: ModelBundle, submodel: ModuleType, submodel_name: str) -> list[str]:
+    """Return missing field names. Logs a loud WARNING if any are missing."""
+    missing = [
+        f for f in submodel.REQUIRED_FIELDS
+        if getattr(bundle, f, None) is None
+    ]
+    if missing:
+        log.warning(
+            "MISSING INPUTS: %s for '%s' — fields %s are None. "
+            "Check dataset paths/config. This dataset will be OMITTED from "
+            "the %s comparison.",
+            submodel_name, bundle.label, missing, submodel_name,
+        )
+    return missing
+
+
+def _run_submodel(
+    submodel: ModuleType,
+    bundle: ModelBundle,
+) -> dict[str, pl.DataFrame]:
+    """Invoke a submodel's ``summarize()`` with the right arguments."""
+    if submodel is work_school_location:
+        wc = bundle.get_weight_col("wsloc_results")
+        wsloc = bundle.wsloc_results.collect()
+        # If bundle has person weights from a separate persons table, join them
+        needs_weight_join = (
+            wc
+            and bundle.persons is not None
+            and wc not in wsloc.columns
+        )
+        if needs_weight_join:
+            persons = bundle.persons.select(
+                "hh_id", "person_id", wc,
+            ).collect()
+            wsloc = wsloc.join(
+                persons,
+                on=["hh_id", "person_id"],
+                how="left",
+            ).with_columns(pl.col(wc).fill_null(0.0))
+        return submodel.summarize(
+            wsloc=wsloc,
+            taz_data=bundle.taz_data.collect(),
+            dist_skim=bundle.dist_skim.collect(),
+            weight_col=wc,
+            sampleshare=bundle.sampleshare,
+        )
+    if submodel is auto_ownership:
+        return submodel.summarize(
+            households=bundle.households.collect(),
+            ao_results=bundle.ao_results.collect(),
+            taz_data=bundle.taz_data.collect(),
+            sampleshare=bundle.sampleshare,
+        )
+    if submodel is work_from_home:
+        return submodel.summarize(
+            cdap_results=bundle.cdap_results.collect(),
+            households=bundle.households.collect(),
+            taz_data=bundle.taz_data.collect(),
+            sampleshare=bundle.sampleshare,
+        )
+    if submodel is daily_activity_pattern:
+        return submodel.summarize(
+            cdap_results=bundle.cdap_results.collect(),
+            weight_col=bundle.get_weight_col("cdap_results"),
+            sampleshare=bundle.sampleshare,
+        )
+    if submodel is nonwork_dest_choice:
+        return submodel.summarize(
+            indiv_tour_data=bundle.indiv_tour_data.collect(),
+            dist_skim=bundle.dist_skim.collect(),
+            joint_tour_data=(
+                bundle.joint_tour_data.collect()
+                if bundle.joint_tour_data is not None
+                else None
+            ),
+            weight_col=bundle.get_weight_col("indiv_tour_data"),
+            sampleshare=bundle.sampleshare,
+        )
+    if submodel is tour_mode_choice:
+        return submodel.summarize(
+            indiv_tour_data=bundle.indiv_tour_data.collect(),
+            ao_results=bundle.ao_results.collect(),
+            households=bundle.households.collect(),
+            persons=(
+                bundle.persons.collect()
+                if bundle.persons is not None
+                else None
+            ),
+            joint_tour_data=(
+                bundle.joint_tour_data.collect()
+                if bundle.joint_tour_data is not None
+                else None
+            ),
+            weight_col=bundle.get_weight_col("indiv_tour_data"),
+            sampleshare=bundle.sampleshare,
+        )
+    if submodel is trip_mode_choice:
+        return submodel.summarize(
+            indiv_trip_data=bundle.indiv_trip_data.collect(),
+            joint_trip_data=(
+                bundle.joint_trip_data.collect()
+                if bundle.joint_trip_data is not None
+                else None
+            ),
+            weight_col=bundle.get_weight_col("indiv_trip_data"),
+            sampleshare=bundle.sampleshare,
+        )
+    if submodel is atwork_subtour:
+        return submodel.summarize(
+            indiv_tour_data=bundle.indiv_tour_data.collect(),
+            ao_results=bundle.ao_results.collect(),
+            households=bundle.households.collect(),
+            dist_skim=bundle.dist_skim.collect(),
+            weight_col=bundle.get_weight_col("indiv_tour_data"),
+            sampleshare=bundle.sampleshare,
+        )
+    msg = f"Unknown submodel module: {submodel}"
+    raise ValueError(msg)
+
+
+def _write_csvs(
+    tables: dict[str, pl.DataFrame],
+    output_dir: Path,
+    label: str,
+    submodel_name: str,
+) -> None:
+    """Write each DataFrame as ``{output_dir}/{label}/{submodel}_{table}.csv``."""
+    out = output_dir / label
+    out.mkdir(parents=True, exist_ok=True)
+    for table_name, df in tables.items():
+        if df is not None:
+            path = out / f"{submodel_name}_{table_name}.csv"
+            df.write_csv(path)
+            log.info("Wrote %s", path)
+
+
+def run(  # noqa: C901, PLR0912
+    config_dir: Path,  # noqa: ARG001
+    cfg: dict,
+    **kwargs: object,  # noqa: ARG001
+) -> None:
+    """Produce calibration summaries by loading data bundles and running pure submodel functions."""
+    # Ensure root logger has a timestamp format
+    root = logging.getLogger()
+    if not root.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+    else:
+        fmt = logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s: %(message)s", datefmt="%H:%M:%S",
+        )
+        for h in root.handlers:
+            h.setFormatter(fmt)
+
+    run_cfg = parse_config(cfg)
+
+    if not run_cfg.datasets:
+        log.warning("No datasets configured — nothing to do")
+        return
+    if not run_cfg.submodels:
+        log.warning("No submodels configured — nothing to do")
+        return
+
+    # {label: {submodel_name: {table_name: DataFrame}}}
+    all_results: dict[str, dict[str, dict[str, pl.DataFrame]]] = {}
+
+    t_total = time.perf_counter()
+
+    # --- Load all bundles up front ---
+    bundles: list[ModelBundle] = []
+    for ds_cfg in run_cfg.datasets:
+        t_ds = time.perf_counter()
+        bundle = load_bundle(ds_cfg)
+        log.info("Loaded %s (%.1fs)", ds_cfg.label, time.perf_counter() - t_ds)
+        bundles.append(bundle)
+        all_results[bundle.label] = {}
+
+    # --- Run submodels across all bundles ---
+    for submodel_name in run_cfg.submodels:
+        mod = SUBMODELS.get(submodel_name)
+        if mod is None:
+            log.warning("Unknown submodel: %s — skipping", submodel_name)
+            continue
+
+        for bundle in bundles:
+            missing = _check_bundle_inputs(bundle, mod, submodel_name)
+            if missing:
+                continue
+
+            t_sub = time.perf_counter()
+            tables = _run_submodel(mod, bundle)
+            log.info(
+                "%s / %s (%.1fs)",
+                submodel_name, bundle.label, time.perf_counter() - t_sub,
+            )
+            all_results[bundle.label][submodel_name] = tables
+            if run_cfg.write_csv:
+                _write_csvs(tables, run_cfg.output_dir, bundle.label, submodel_name)
+
+    # Comparison across datasets
+    if len(run_cfg.datasets) > 1:
+        log.info("Building comparison across datasets")
+        comparisons = build_comparison(all_results)
+        if run_cfg.write_csv:
+            write_comparison_csvs(comparisons, run_cfg.output_dir)
+
+    # Identify survey datasets (those using per-record weights, not sampleshare)
+    survey_labels = {
+        ds_cfg.label for ds_cfg in run_cfg.datasets if ds_cfg.weight_cols
+    }
+
+    # HTML calibration report
+    t_rpt = time.perf_counter()
+    report_path = write_report(
+        all_results, run_cfg.output_dir,
+        survey_labels=survey_labels,
+        report_name=run_cfg.report_name,
+        notes=run_cfg.notes,
+    )
+    log.info("Wrote calibration report: %s (%.1fs)", report_path, time.perf_counter() - t_rpt)
+    log.info("Calibration complete (%.1fs total)", time.perf_counter() - t_total)
+

--- a/src/tm1/steps/summaries/calibration/bundle.py
+++ b/src/tm1/steps/summaries/calibration/bundle.py
@@ -1,0 +1,62 @@
+"""Typed data bundle for calibration summaries.
+
+A ModelBundle holds all the "model tables" for one labeled dataset (e.g. a
+CTRAMP run, an ActivitySim run, or a BATS survey).  Fields are Optional so
+that a survey bundle can omit tables it doesn't produce — submodel functions
+simply check whether the fields they need are present.
+
+Weighting is **either** a uniform ``sampleshare`` expansion *or* explicit
+per-table ``weight_cols`` — never both.  ``get_weight_col()`` returns the
+column name for a given table, or *None* when uniform weighting is in effect.
+"""
+
+from dataclasses import dataclass, field
+
+import polars as pl
+
+
+@dataclass
+class ModelBundle:
+    """All tables for one labeled dataset.
+
+    Attributes:
+        label: Human-readable identifier (e.g. "CTRAMP_v161", "BATS_2023").
+        sampleshare: Population fraction.  1.0 for census/survey, 0.5 for 50%
+            synthetic-population sample, etc.
+        weight_cols: Mapping of table_name → weight column name.  When
+            non-empty, ``sampleshare`` must be 1.0.  No "default" fallback —
+            every table that needs a weight must be listed explicitly.
+
+    Convention: tables are stored as ``pl.LazyFrame`` so the actual read is
+    deferred until a submodel ``.collect()``s only the columns it needs.
+    Binary formats (TPP, OMX) are read eagerly then wrapped with ``.lazy()``.
+    """
+
+    # ---- identity --------------------------------------------------------
+    label: str
+    sampleshare: float = 1.0
+    weight_cols: dict[str, str] = field(default_factory=dict)
+
+    def get_weight_col(self, table_name: str) -> str | None:
+        """Return the weight column for *table_name*, or *None* for uniform weighting."""
+        return self.weight_cols.get(table_name)
+
+    # ---- shared / geography ----------------------------------------------
+    taz_data: pl.LazyFrame | None = None
+    dist_skim: pl.LazyFrame | None = None
+
+    # ---- population tables -----------------------------------------------
+    persons: pl.LazyFrame | None = None
+    households: pl.LazyFrame | None = None
+
+    # ---- CTRAMP / ActivitySim model outputs ------------------------------
+    wsloc_results: pl.LazyFrame | None = None
+    ao_results: pl.LazyFrame | None = None
+    cdap_results: pl.LazyFrame | None = None
+    indiv_tour_data: pl.LazyFrame | None = None
+    joint_tour_data: pl.LazyFrame | None = None
+    indiv_trip_data: pl.LazyFrame | None = None
+    joint_trip_data: pl.LazyFrame | None = None
+
+    # ---- input paths (for provenance / logging) --------------------------
+    source_paths: dict[str, str] = field(default_factory=dict)

--- a/src/tm1/steps/summaries/calibration/compare.py
+++ b/src/tm1/steps/summaries/calibration/compare.py
@@ -1,0 +1,133 @@
+"""Side-by-side comparison of summarization results across labeled datasets."""
+
+import polars as pl
+
+
+def build_comparison(
+    results: dict[str, dict[str, dict[str, pl.DataFrame]]],
+) -> dict[str, dict[str, pl.DataFrame]]:
+    """Merge results from multiple datasets into comparison DataFrames.
+
+    Args:
+        results: ``{label: {submodel: {table_name: DataFrame}}}``
+
+    Returns:
+        ``{submodel: {table_name: comparison_DataFrame}}`` where each
+        comparison DataFrame has the original index columns plus one value
+        column per label (suffixed with the label name).
+    """
+    labels = list(results)
+    if len(labels) < 2:  # noqa: PLR2004
+        return {}
+
+    all_submodels = _collect_submodels(results)
+    comparisons: dict[str, dict[str, pl.DataFrame]] = {}
+
+    for submodel in sorted(all_submodels):
+        tables = _compare_submodel(results, labels, submodel)
+        if tables:
+            comparisons[submodel] = tables
+
+    return comparisons
+
+
+def _collect_submodels(
+    results: dict[str, dict[str, dict[str, pl.DataFrame]]],
+) -> set[str]:
+    """Return the union of submodel names across all labels."""
+    out: set[str] = set()
+    for per_label in results.values():
+        out.update(per_label)
+    return out
+
+
+def _compare_submodel(
+    results: dict[str, dict[str, dict[str, pl.DataFrame]]],
+    labels: list[str],
+    submodel: str,
+) -> dict[str, pl.DataFrame]:
+    """Build comparison tables for one submodel across labels."""
+    table_names: set[str] = set()
+    for label in labels:
+        sub = results.get(label, {}).get(submodel, {})
+        if sub:
+            table_names.update(sub)
+
+    # Tables containing raw samples should not be merged (they are used
+    # directly by renderers, not compared side-by-side).
+    _SKIP_PREFIXES = ("dist_samples",)
+
+    out: dict[str, pl.DataFrame] = {}
+    for table_name in sorted(table_names):
+        if any(table_name.startswith(p) for p in _SKIP_PREFIXES):
+            continue
+        frames: list[tuple[str, pl.DataFrame]] = []
+        for label in labels:
+            df = results.get(label, {}).get(submodel, {}).get(table_name)
+            if df is not None:
+                frames.append((label, df))
+        if len(frames) < 2:  # noqa: PLR2004
+            continue
+        merged = _merge_frames(frames, table_name)
+        if merged is not None:
+            out[table_name] = merged
+    return out
+
+
+def write_comparison_csvs(
+    comparisons: dict[str, dict[str, pl.DataFrame]],
+    output_dir: object,
+) -> None:
+    """Write comparison DataFrames as CSVs under *output_dir*/comparison/."""
+    from pathlib import Path  # noqa: PLC0415
+
+    out = Path(output_dir) / "comparison"
+    out.mkdir(parents=True, exist_ok=True)
+
+    for submodel, tables in comparisons.items():
+        for table_name, df in tables.items():
+            path = out / f"{submodel}_{table_name}.csv"
+            df.write_csv(path)
+
+
+# ---------------------------------------------------------------------------
+# Internal
+# ---------------------------------------------------------------------------
+
+def _merge_frames(
+    frames: list[tuple[str, pl.DataFrame]],
+    table_name: str,  # noqa: ARG001
+) -> pl.DataFrame | None:
+    """Merge multiple labeled DataFrames on shared index columns.
+
+    Strategy: identify columns that look like indices (non-float, present in
+    all frames) and join on those, suffixing value columns with the label.
+    """
+    if not frames:
+        return None
+
+    # Find common non-float columns to use as join keys
+    first_label, first_df = frames[0]
+    if first_df.width == 0:
+        return None
+    index_cols = [
+        c
+        for c in first_df.columns
+        if first_df.schema[c] not in (pl.Float32, pl.Float64)
+    ]
+    if not index_cols:
+        # Fall back to first column as index
+        index_cols = [first_df.columns[0]]
+
+    value_cols = [c for c in first_df.columns if c not in index_cols]
+
+    # Start with the first frame
+    merged = first_df.rename({vc: f"{vc}_{first_label}" for vc in value_cols})
+
+    for label, df in frames[1:]:
+        if df.width == 0:
+            continue
+        renamed = df.rename({vc: f"{vc}_{label}" for vc in value_cols if vc in df.columns})
+        merged = merged.join(renamed, on=index_cols, how="full", coalesce=True)
+
+    return merged

--- a/src/tm1/steps/summaries/calibration/config.py
+++ b/src/tm1/steps/summaries/calibration/config.py
@@ -1,0 +1,123 @@
+"""Configuration dataclasses for calibration summaries."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from tm1.project.config import step_config
+
+
+@dataclass
+class DatasetConfig:
+    """One labeled dataset (e.g. a CTRAMP run, a BATS survey).
+
+    Weighting is **either** a uniform ``sampleshare`` expansion *or* explicit
+    per-table ``weight_cols`` — never both.  When ``weight_cols`` is
+    non-empty, ``sampleshare`` is forced to 1.0.
+
+    Attributes:
+        label: Human-readable name shown in outputs.
+        paths: Mapping of table name → file path.  Table names must match
+            :class:`~.bundle.ModelBundle` field names (e.g. ``wsloc_results``,
+            ``taz_data``, ``dist_skim``).
+        sampleshare: Population fraction (1.0 for survey/census).
+        weight_cols: Mapping of table name → weight column name.  No
+            "default" fallback — every table that needs a weight must be
+            listed explicitly.
+        format: Source data format — drives column renaming to canonical names.
+            One of ``"ctramp"``, ``"activitysim"``, or ``"survey"``.
+    """
+
+    label: str
+    paths: dict[str, Path] = field(default_factory=dict)
+    sampleshare: float = 1.0
+    weight_cols: dict[str, str] = field(default_factory=dict)
+    format: str = "ctramp"
+
+
+@dataclass
+class CalibrationRunConfig:
+    """Top-level config for a calibration comparison run.
+
+    Attributes:
+        output_dir: Where CSVs and comparison files are written.
+        datasets: One or more labeled datasets to summarize/compare.
+        submodels: Which submodel summarizers to run.
+        write_csv: Whether to write per-dataset CSV files.
+    """
+
+    output_dir: Path
+    report_name: str = "calibration_report.html"
+    datasets: list[DatasetConfig] = field(default_factory=list)
+    submodels: list[str] = field(default_factory=list)
+    write_csv: bool = True
+    notes: str = ""
+
+
+def parse_config(cfg: dict) -> CalibrationRunConfig:
+    """Parse the ``steps.calibration`` dict from scenario_config.yaml.
+
+    Expected shape::
+
+        calibration:
+          output_dir: "path/to/output"
+          datasets:
+            - label: "CTRAMP_v161"
+              sampleshare: 0.5
+              paths:
+                wsloc_results: "..."
+                taz_data: "..."
+          submodels:
+            - work_school_location
+            - auto_ownership
+    """
+    calib = step_config(cfg, "calibration")
+
+    output_dir = Path(calib.get("output_dir", "output/calibration"))
+
+    datasets = []
+    for ds in calib.get("datasets", []):
+        raw_wc = ds.get("weight_col", {})
+        has_sampleshare = "sampleshare" in ds
+        has_weights = bool(raw_wc)
+
+        if has_sampleshare and has_weights:
+            msg = (
+                f"Dataset {ds['label']!r}: 'sampleshare' and 'weight_col' are "
+                f"mutually exclusive — specify one or the other."
+            )
+            raise ValueError(msg)
+
+        if has_weights:
+            if not isinstance(raw_wc, dict):
+                msg = (
+                    f"Dataset {ds['label']!r}: 'weight_col' must be a mapping "
+                    f"of table_name → column_name, got {type(raw_wc).__name__}."
+                )
+                raise TypeError(msg)
+            weight_cols = dict(raw_wc)
+            sampleshare = 1.0
+        else:
+            weight_cols = {}
+            sampleshare = float(ds.get("sampleshare", 1.0))
+
+        datasets.append(
+            DatasetConfig(
+                label=ds["label"],
+                paths={k: Path(v) for k, v in ds.get("paths", {}).items()},
+                sampleshare=sampleshare,
+                weight_cols=weight_cols,
+                format=ds.get("format", "ctramp"),
+            ),
+        )
+
+    submodels = calib.get("submodels", [])
+    write_csv = bool(calib.get("write_csv", True))
+
+    return CalibrationRunConfig(
+        output_dir=output_dir,
+        report_name=calib.get("report_name", "calibration_report.html"),
+        datasets=datasets,
+        submodels=submodels,
+        write_csv=write_csv,
+        notes=calib.get("notes", ""),
+    )

--- a/src/tm1/steps/summaries/calibration/enums.py
+++ b/src/tm1/steps/summaries/calibration/enums.py
@@ -1,0 +1,462 @@
+"""Data models for calibration processing using Pydantic for validation.
+
+Field Name Standardization Strategy:
+- Model attributes use snake_case (Python convention): home_taz, work_location
+- Field aliases accept original names: ZONE, WorkLocation, HomeTAZ
+- Use model_dump() to export with standardized names
+- Use model_dump(by_alias=True) to export with original names
+
+"""
+
+from enum import Enum, StrEnum
+from typing import Literal, Self
+
+import pandas as pd
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic_core import CoreSchema, core_schema
+
+
+################################################################
+###  Class for Labeled Enums
+################################################################
+class LabeledEnum(Enum):
+    """Base enum class that auto-validates by id or label."""
+
+    @property
+    def id(self) -> int | str:
+        """Return the numeric or string identifier."""
+        return self.value[0]
+
+    @property
+    def label(self) -> str:
+        """Return the human-readable label."""
+        return self.value[1]
+
+    @classmethod
+    def from_value(cls, v: int | str) -> Self:
+        """Look up a member by id or label."""
+        if isinstance(v, cls):
+            return v
+        for member in cls:
+            if v in (member.id, member.label):
+                return member
+        msg = f"Invalid county: {v}"
+        raise ValueError(msg)
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source: type, handler: object) -> CoreSchema:
+        """Return Pydantic core schema for enum validation."""
+        return core_schema.no_info_plain_validator_function(cls.from_value)
+
+
+################################################################
+### Codebook Definitions for CTRAMP
+################################################################
+
+
+class CTRAMPCounty(LabeledEnum):
+    """Nine Bay Area counties."""
+
+    SAN_FRANCISCO = (1, "San Francisco")
+    SAN_MATEO = (2, "San Mateo")
+    SANTA_CLARA = (3, "Santa Clara")
+    ALAMEDA = (4, "Alameda")
+    CONTRA_COSTA = (5, "Contra Costa")
+    SOLANO = (6, "Solano")
+    NAPA = (7, "Napa")
+    SONOMA = (8, "Sonoma")
+    MARIN = (9, "Marin")
+
+
+class CTRAMPPersonType(LabeledEnum):
+    """Eight CTRAMP person types."""
+
+    FULL_TIME_WORKER = (1, "Full-time worker")
+    PART_TIME_WORKER = (2, "Part-time worker")
+    UNIVERSITY_STUDENT = (3, "University student")
+    NON_WORKER = (4, "Nonworker")
+    RETIRED = (5, "Retired")
+    CHILD_DRIVING_AGE = (6, "Driving-age child")
+    CHILD_PRE_DRIVING_AGE = (7, "Pre-driving-age child")
+    CHILD_UNDER_5 = (8, "Child too young for school")
+
+
+class CTRAMPActivityPattern(LabeledEnum):
+    """Enumeration for activity pattern."""
+
+    MANDATORY = "M", "Mandatory"
+    NON_MANDATORY = "N", "Non-mandatory"
+    HOME = "H", "Home"
+
+
+class CTRAMPSimplePurpose(LabeledEnum):
+    """Enumeration for simple tour purpose."""
+
+    WORK = "work"
+    UNIVERSITY = "university"
+    SCHOOL = "school"
+    ATWORK = "atwork"
+    IND_DISC = "ind_disc"
+    IND_MAINT = "ind_maint"
+
+
+class CTRAMPPurpose(LabeledEnum):
+    """Enumeration for tour purpose."""
+
+    HOME = ("Home", "Home")
+    WORK_LOW = ("work_low", "Work - Low income")
+    WORK_MED = ("work_med", "Work - Medium income")
+    WORK_HIGH = ("work_high", "Work - High income")
+    WORK_VERY_HIGH = ("work_very high", "Work - Very High income")
+    UNIVERSITY = ("university", "University")
+    SCHOOL_HIGH = ("school_high", "School - High school")
+    SCHOOL_GRADE = ("school_grade", "School - Grade school")
+    ATWORK_BUSINESS = ("atwork_business", "At-work - Business")
+    ATWORK_EAT = ("atwork_eat", "At-work - Eating")
+    ATWORK_MAINT = ("atwork_maint", "At-work - Maintenance")
+    EATOUT = ("eatout", "Eating out")
+    ESCORT_KIDS = ("escort_kids", "Escort - Kids")
+    ESCORT_NO_KIDS = ("escort_no kids", "Escort - No kids")
+    SHOPPING = ("shopping", "Shopping")
+    SOCIAL = ("social", "Social/recreational")
+    OTHMAINT = ("othmaint", "Other maintenance")
+    OTHDISCR = ("othdiscr", "Other discretionary")
+
+    @property
+    def simple_purpose(self) -> CTRAMPSimplePurpose:
+        """Map detailed purpose to simplified category."""
+        mapping = {
+            self.ATWORK_BUSINESS: CTRAMPSimplePurpose.ATWORK,
+            self.ATWORK_EAT: CTRAMPSimplePurpose.ATWORK,
+            self.ATWORK_MAINT: CTRAMPSimplePurpose.ATWORK,
+            self.EATOUT: CTRAMPSimplePurpose.IND_DISC,
+            self.ESCORT_KIDS: CTRAMPSimplePurpose.IND_MAINT,
+            self.ESCORT_NO_KIDS: CTRAMPSimplePurpose.IND_MAINT,
+            self.OTHDISCR: CTRAMPSimplePurpose.IND_DISC,
+            self.OTHMAINT: CTRAMPSimplePurpose.IND_MAINT,
+            self.SCHOOL_GRADE: CTRAMPSimplePurpose.SCHOOL,
+            self.SCHOOL_HIGH: CTRAMPSimplePurpose.SCHOOL,
+            self.SHOPPING: CTRAMPSimplePurpose.IND_MAINT,
+            self.SOCIAL: CTRAMPSimplePurpose.IND_DISC,
+            self.UNIVERSITY: CTRAMPSimplePurpose.UNIVERSITY,
+            self.WORK_HIGH: CTRAMPSimplePurpose.WORK,
+            self.WORK_LOW: CTRAMPSimplePurpose.WORK,
+            self.WORK_MED: CTRAMPSimplePurpose.WORK,
+            self.WORK_VERY_HIGH: CTRAMPSimplePurpose.WORK,
+        }
+        return mapping.get(self)
+
+
+class CTRAMPModeType(LabeledEnum):
+    """Enumeration for mode choice."""
+
+    DA = 1, "Drive alone"
+    DA_TOLL = 2, "Drive alone - toll"
+    SR2 = 3, "Shared ride 2"
+    SR2_TOLL = 4, "Shared ride 2 - toll"
+    SR3 = 5, "Shared ride 3+"
+    SR3_TOLL = 6, "Shared ride 3+ - toll"
+    WALK = 7, "Walk"
+    BIKE = 8, "Bike"
+    WLK_LOC_WLK = 9, "Walk to local bus"
+    WLK_LRF_WLK = 10, "Walk to light rail or ferry"
+    WLK_EXP_WLK = 11, "Walk to express bus"
+    WLK_HVY_WLK = 12, "Walk to heavy rail"
+    WLK_COM_WLK = 13, "Walk to commuter rail"
+    DRV_LOC_WLK = 14, "Drive to local bus"
+    DRV_LRF_WLK = 15, "Drive to light rail or ferry"
+    DRV_EXP_WLK = 16, "Drive to express bus"
+    DRV_HVY_WLK = 17, "Drive to heavy rail"
+    DRV_COM_WLK = 18, "Drive to commuter rail"
+    TAXI = 19, "Taxi"
+    TNC = 20, "TNC - single party"
+    TNC2 = 21, "TNC - shared"
+
+
+class CTRAMPTransitMode(StrEnum):
+    """Transit sub-mode categories."""
+
+    LOCAL = "Local"
+    EXPRESS = "Express"
+    HEAVY_RAIL = "HeavyRail"
+    COMM_RAIL = "CommRail"
+    WLK_LRT = "Light Rail - Walk"
+    DRV_LRT = "Light Rail - Drive"
+    WLK_FERRY = "Ferry - Walk"
+    DRV_FERRY = "Ferry - Drive"
+
+
+class IndivJoint(StrEnum):
+    """Individual vs. joint tour indicator."""
+
+    INDIV = "indiv"
+    JOINT = "joint"
+
+
+################################################################
+### Data Model for Output Results
+################################################################
+
+
+# Usual Work School Location
+class CountyTripSummary(BaseModel):
+    """Model for county-to-county summary results."""
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+    home_county_name: CTRAMPCounty = Field(alias="HomeCounty_name")
+    San_Francisco: float = Field(alias="San Francisco", ge=0)
+    San_Mateo: float = Field(alias="San Mateo", ge=0)
+    Santa_Clara: float = Field(alias="Santa Clara", ge=0)
+    Alameda: float = Field(ge=0)
+    Contra_Costa: float = Field(alias="Contra Costa", ge=0)
+    Solano: float = Field(ge=0)
+    Napa: float = Field(ge=0)
+    Sonoma: float = Field(ge=0)
+    Marin: float = Field(ge=0)
+
+
+class TripLengthFrequency(BaseModel):
+    """Model for trip length frequency distribution."""
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+
+    distbin: int = Field(ge=1, description="Distance bin")
+    # County columns
+    San_Francisco: float = Field(alias="San Francisco", ge=0)
+    San_Mateo: float = Field(alias="San Mateo", ge=0)
+    Santa_Clara: float = Field(alias="Santa Clara", ge=0)
+    Alameda: float = Field(ge=0)
+    Contra_Costa: float = Field(alias="Contra Costa", ge=0)
+    Solano: float = Field(ge=0)
+    Napa: float = Field(ge=0)
+    Sonoma: float = Field(ge=0)
+    Marin: float = Field(ge=0)
+
+    # Total column - REQUIRED
+    Total: float = Field(ge=0, description="Total across all counties")
+
+
+class AverageTripLength(BaseModel):
+    """Model for average trip length by county and type."""
+
+    county: CTRAMPCounty | Literal["Total"]
+    work: float
+    univ: float
+    school: float
+
+
+# Auto Ownership
+class AutoOwnershipModel(BaseModel):
+    """Auto ownership vehicle-count columns."""
+
+    ZER0_VEHICLE: float = Field(ge=0, alias="0") | Literal["NA"]
+    ONE_VEHICLE: float = Field(ge=0, alias="1") | Literal["NA"]
+    TWO_VEHICLE: float = Field(ge=0, alias="2") | Literal["NA"]
+    THREE_VEHICLE: float = Field(ge=0, alias="3") | Literal["NA"]
+    FOUR_PLUS_VEHICLE: float = Field(ge=0, alias="4") | Literal["NA"]
+
+
+class AutoOwnershipCountySummary(AutoOwnershipModel):
+    """Model for auto ownership county summmary."""
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+    COUNTY: CTRAMPCounty
+    county_name: CTRAMPCounty
+
+
+class AutoOwnershipTAZSummary(AutoOwnershipModel):
+    """Auto ownership by TAZ."""
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+    TAZ: int = Field(ge=1, alias="taz")
+    source: str
+
+
+class AutoOwnershipLongSummary(BaseModel):
+    """Auto ownership in long (tidy) format."""
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+    TAZ: int = Field(ge=1, alias="taz")
+    num_vehicles: float = Field(ge=0)
+    num_hh: float = Field(ge=0, description="Number of households")
+    source: str
+
+
+# CDAP
+class CDAPSummary(BaseModel):
+    """CDAP summary by person type and activity pattern."""
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+    person_type: CTRAMPPersonType
+    home: float = Field(ge=0, alias="H") | Literal["NA"]
+    mandatory: float = Field(ge=0, alias="M") | Literal["NA"]
+    non_mandatory: float = Field(ge=0, alias="N") | Literal["NA"]
+
+
+class CDAPSummaryBATS(BaseModel):
+    """CDAP summary from BATS survey data."""
+
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
+    person_type: CTRAMPPersonType = Field(alias="PersonType")
+    activity_pattern: CTRAMPActivityPattern = Field(alias="DAP")
+    num_pers: float
+
+
+# Non-Work Choice Destination
+class NonMandAvgTripLength(BaseModel):
+    """Average trip length by non-mandatory purpose."""
+
+    trip_purpose: CTRAMPPurpose = Field(alias="trip_type")
+    avg_trip_length: float = Field(ge=0, alias="mean_trip_length")
+
+
+class NonMandTripLengthFrequency(BaseModel):
+    """Trip-length frequency distribution for non-mandatory purposes."""
+
+    distbin: int = Field(ge=1, description="Distance bin")
+    escort: float = Field(ge=0, alias=("Escort"))
+    shop: float = Field(ge=0, alias=("Shop"))
+    maintenance: float = Field(ge=0, alias=("Maintenance"))
+    eat_out: float = Field(ge=0, alias=("eatout"))
+    visit: float = Field(ge=0, alias=("Visit"))
+    discretionary: float = Field(ge=0)
+    at_work: float = Field(ge=0, alias=("atwork"))
+
+
+# Tour Mode Choice
+class TourModeChoiceModel(BaseModel):
+    """Base tour mode choice fields."""
+
+    indiv_joint: IndivJoint
+    tour_purpose: CTRAMPPurpose
+    zero_auto: float = Field(alias=("Autos=0"))
+    autos_less_than_workers: float = Field(alias=("Autos<Workers"))
+    autos_greater_than_workers: float = Field(alias=("Autos>=Workers"))
+
+
+class TourModeSummary(TourModeChoiceModel):
+    """Tour mode summary with CTRAMP mode."""
+
+    tour_mode: CTRAMPModeType
+
+
+# TODO: Create Transit Mode Class
+class TourModeTransitSummary(TourModeChoiceModel):
+    """Tour mode summary for transit sub-modes."""
+
+    tour_mode: CTRAMPTransitMode
+
+
+# Trip Mode Choice
+class TripModeSummary(BaseModel):
+    """Trip mode choice summary."""
+
+    indiv_joint: IndivJoint
+    tour_purpose: CTRAMPPurpose
+    tour_mode: CTRAMPModeType
+    trip_mode: CTRAMPModeType
+    num_trips: float
+
+
+class TripModeTrnSummary(BaseModel):
+    """Transit trip mode summary by access mode and sub-mode."""
+
+    key: str
+    trn_access_mode: str
+    trn_submode: CTRAMPTransitMode
+    orig_sd_name: str = Field(alias="orig_SD_name")
+    dest_sd_name: str = Field(alias="dest_SD_name")
+    simple_purpose: CTRAMPSimplePurpose
+    num_trips: float
+
+
+################################################################
+# # Helper functions for DataFrame validation
+################################################################
+def validate_dataframe(
+    df: pd.DataFrame, model_class: type[BaseModel], expected_rows: int | None = None
+) -> None:
+    """Validate DataFrame rows against Pydantic model.
+
+    Args:
+        df: DataFrame to validate the Pydantic model
+        model_class: Model Class
+        expected_rows: Expected number of rows for validation
+                        If None, does not validate for row count
+
+    Raises:
+        ValidationError: If any row fails validation
+
+    """
+    total_rows = len(df)
+
+    # Check row count first if expected_rows is not none
+    if expected_rows is not None and total_rows != expected_rows:
+        msg = f"{model_class.__name__} has {total_rows}, expected {expected_rows}"
+        raise ValueError(msg)
+    # Convert entire DataFrame to list of dicts once
+    rows = df.to_dict(orient="records")
+
+    # Batch validate with progress reporting
+    batch_size = 100_000
+    error_groups: dict[str, list[int]] = {}
+    max_unique_errors = 10
+
+    for batch_start in range(0, total_rows, batch_size):
+        batch_end = min(batch_start + batch_size, total_rows)
+        batch = rows[batch_start:batch_end]
+
+        # Validate each row in batch
+        for i, row in enumerate(batch):
+            row_idx = batch_start + i
+            try:
+                model_class(**row)
+            except ValidationError as e:
+                msg = str(e)
+                if msg not in error_groups:
+                    error_groups[msg] = []
+                error_groups[msg].append(row_idx)
+
+                if len(error_groups) >= max_unique_errors:
+                    break
+        if len(error_groups) >= max_unique_errors:
+            break
+
+    _report_errors(error_groups)
+
+
+def _report_errors(error_groups: dict[str, list[int]]) -> None:
+    """Report validation errors for a DataFrame."""
+    if not error_groups:
+        return
+
+    total_error_count = sum(len(rows) for rows in error_groups.values())
+
+    # Format error summary
+    error_lines = []
+    max_rows_to_show = 3
+
+    for msg, row_indices in error_groups.items():
+        num_affected = len(row_indices)
+
+        if num_affected <= max_rows_to_show:
+            rows_str = f"Row(s) {', '.join(map(str, row_indices))}"
+        else:
+            shown = row_indices[:max_rows_to_show]
+            rows_str = f"{num_affected} rows (e.g., {', '.join(map(str, shown))})"
+
+        error_lines.append(f"  {rows_str}: {msg}")
+
+    error_summary = "\n".join(error_lines)
+    num_unique = len(error_groups)
+
+    summary_msg = (
+        f"Found {num_unique} unique error type"
+        f"{'s' if num_unique > 1 else ''} "
+        f"affecting {total_error_count} row"
+        f"{'s' if total_error_count > 1 else ''}:\n"
+        f"{error_summary}"
+    )
+
+    raise ValueError(summary_msg)

--- a/src/tm1/steps/summaries/calibration/io.py
+++ b/src/tm1/steps/summaries/calibration/io.py
@@ -1,0 +1,409 @@
+"""Unified data readers for calibration summaries.
+
+Handles CSV, TPP (Cube binary), and OMX skim formats behind a single
+interface.  All readers return ``pl.LazyFrame`` so downstream code can
+select only the columns it needs before collecting.
+
+Column names are normalised to **canonical** (snake_case, platform-neutral)
+names on load via :data:`COLUMN_MAPS` so that downstream summarize functions
+never need to know the source format.
+"""
+
+import logging
+import time
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+
+from tm1.steps.summaries.ctramp_output import MODE_TO_INT, PTYPE_LABELS
+
+log = logging.getLogger(__name__)
+
+# Cache for expensive skim reads keyed by resolved absolute path.
+# Populated by read_skim(); cleared between runs if needed.
+_skim_cache: dict[str, pl.LazyFrame] = {}
+
+
+# ---------------------------------------------------------------------------
+# Canonical column maps  (format → table → {source_col: canonical_col})
+# Only columns that actually differ from canonical need to be listed.
+# Columns already in canonical form pass through untouched.
+# ---------------------------------------------------------------------------
+
+COLUMN_MAPS: dict[str, dict[str, dict[str, str]]] = {
+    "ctramp": {
+        "taz_data": {"ZONE": "zone", "COUNTY": "county"},
+        "dist_skim": {"DIST": "dist"},
+        "households": {"HHID": "hh_id", "TAZ": "home_taz", "taz": "home_taz"},
+        "persons": {
+            "HHID": "hh_id",
+            "PersonID": "person_id",
+            "PersonType": "person_type",
+            "ActivityString": "activity_pattern",
+        },
+        "ao_results": {"HHID": "hh_id", "AO": "auto_ownership"},
+        "wsloc_results": {
+            "HHID": "hh_id",
+            "PersonID": "person_id",
+            "HomeTAZ": "home_taz",
+            "WorkLocation": "work_location",
+            "SchoolLocation": "school_location",
+            "StudentCategory": "student_category",
+            "EmploymentCategory": "employment_category",
+        },
+        "cdap_results": {
+            "HHID": "hh_id",
+            "PersonID": "person_id",
+            "PersonType": "person_type",
+            "ActivityString": "activity_pattern",
+        },
+        "persons": {
+            "HHID": "hh_id",
+            "PersonID": "person_id",
+            "PersonType": "person_type",
+            "ActivityString": "activity_pattern",
+            "wfh_choice": "work_from_home",
+        },
+        "indiv_tour_data": {},
+        "joint_tour_data": {},
+        "indiv_trip_data": {},
+        "joint_trip_data": {},
+    },
+    # TODO: populate when ActivitySim column names are finalised
+    "activitysim": {
+        "taz_data": {"ZONE": "zone", "COUNTY": "county"},
+        "dist_skim": {"DIST": "dist"},
+        "households": {
+            "household_id": "hh_id",
+            "home_zone_id": "home_taz",
+            "num_workers": "hworkers",
+        },
+        "ao_results": {
+            "household_id": "hh_id",
+        },
+        "cdap_results": {
+            "household_id": "hh_id",
+            "person_id": "person_id",
+            "cdap_activity": "activity_pattern",
+            "work_from_home": "work_from_home",
+            "ptype": "ptype",
+        },
+        "wsloc_results": {
+            "household_id": "hh_id",
+            "person_id": "person_id",
+            "home_zone_id": "home_taz",
+            # Use assigned_workplace_zone_id: CTRAMP keeps a WorkLocation for
+            # WFH workers too (wfh_choice is an overlay, not an exclusion —
+            # verified 100% of CTRAMP wfh=1 have WorkLocation>0), so ActivitySim
+            # must likewise keep WFH workers at their assigned work TAZ for the
+            # work-distance TLFD to be apples-to-apples (counts match to 0.04%).
+            "assigned_workplace_zone_id": "work_location",
+            "workplace_zone_id": "_workplace_zone_id_raw",
+            "school_zone_id": "school_location",
+        },
+        "indiv_tour_data": {
+            "household_id": "hh_id",
+            "tour_type": "tour_purpose",
+            "primary_purpose": "tour_purpose",
+            "origin": "orig_taz",
+            "destination": "dest_taz",
+        },
+        "joint_tour_data": {
+            "household_id": "hh_id",
+            "tour_type": "tour_purpose",
+            "primary_purpose": "tour_purpose",
+            "origin": "orig_taz",
+            "destination": "dest_taz",
+        },
+        "indiv_trip_data": {
+            "household_id": "hh_id",
+            "tour_type": "tour_purpose",
+            "primary_purpose": "tour_purpose",
+        },
+        "joint_trip_data": {
+            "household_id": "hh_id",
+            "tour_type": "tour_purpose",
+            "primary_purpose": "tour_purpose",
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def read_skim(path: str | Path) -> pl.LazyFrame:
+    """Read a distance-skim file and return a 3-column LazyFrame (orig, dest, DIST).
+
+    Results are cached by resolved path so the same skim file is only read once
+    even when multiple datasets reference it.
+
+    Dispatches by file extension:
+    * ``.csv`` — expects columns ``orig``, ``dest``, ``DIST``.
+    * ``.tpp`` — Cube binary; uses ``cubeio.read_tpp``.
+    * ``.omx``  — OpenMatrix; uses ``openmatrix``.
+    """
+    path = Path(path)
+    cache_key = str(path.resolve())
+    if cache_key in _skim_cache:
+        log.info("Using cached skim: %s", path)
+        return _skim_cache[cache_key]
+
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        lf = _read_skim_csv(path)
+    elif suffix == ".tpp":
+        lf = _read_skim_tpp(path)
+    elif suffix == ".omx":
+        lf = _read_skim_omx(path)
+    else:
+        msg = f"Unsupported skim format: {suffix}"
+        raise ValueError(msg)
+
+    _skim_cache[cache_key] = lf
+    return lf
+
+
+def scan_csv(path: str | Path, **kwargs: object) -> pl.LazyFrame:
+    """Thin wrapper around ``pl.scan_csv`` with sensible defaults."""
+    return pl.scan_csv(path, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Internal skim readers
+# ---------------------------------------------------------------------------
+
+def _read_skim_csv(path: Path) -> pl.LazyFrame:
+    log.info("Reading CSV skim: %s", path)
+    return pl.scan_csv(path).select("orig", "dest", "DIST")
+
+
+def _read_skim_tpp(path: Path) -> pl.LazyFrame:
+    log.info("Reading TPP skim: %s", path)
+    from cubeio import read_tpp  # noqa: PLC0415
+
+    skims = read_tpp(str(path))
+    n_zones = skims["zones"]
+    taz_ids = np.arange(1, n_zones + 1)
+    orig, dest = np.meshgrid(taz_ids, taz_ids, indexing="ij")
+    df = pl.DataFrame({
+        "orig": orig.ravel(),
+        "dest": dest.ravel(),
+        "DIST": skims["data"]["DIST"].ravel(),
+    })
+    return df.lazy()
+
+
+def _read_skim_omx(path: Path) -> pl.LazyFrame:
+    log.info("Reading OMX skim: %s", path)
+    import openmatrix as omx  # noqa: PLC0415
+
+    f = omx.open_file(str(path), "r")
+    try:
+        dist = np.array(f["DIST"])
+        n_zones = dist.shape[0]
+        taz_ids = np.arange(1, n_zones + 1)
+        orig, dest = np.meshgrid(taz_ids, taz_ids, indexing="ij")
+        df = pl.DataFrame({
+            "orig": orig.ravel(),
+            "dest": dest.ravel(),
+            "DIST": dist.ravel(),
+        })
+    finally:
+        f.close()
+    return df.lazy()
+
+
+# ---------------------------------------------------------------------------
+# Bundle loader
+# ---------------------------------------------------------------------------
+
+def load_bundle(dataset_cfg: object) -> object:
+    """Build a :class:`ModelBundle` from a :class:`DatasetConfig`.
+
+    Each key in ``dataset_cfg.paths`` is matched to a ``ModelBundle`` field.
+    ``dist_skim`` is handled via :func:`read_skim`; everything else via
+    :func:`scan_csv`.  After loading, columns are renamed to canonical names
+    according to :data:`COLUMN_MAPS` and ``dataset_cfg.format``.
+    """
+    from .bundle import ModelBundle  # noqa: PLC0415
+
+    cfg = dataset_cfg
+    fmt = getattr(cfg, "format", "ctramp")
+    format_maps = COLUMN_MAPS.get(fmt, {})
+
+    bundle = ModelBundle(
+        label=cfg.label,
+        sampleshare=cfg.sampleshare,
+        weight_cols=cfg.weight_cols,
+        source_paths={k: str(v) for k, v in cfg.paths.items()},
+    )
+
+    for table_name, raw_path in cfg.paths.items():
+        resolved = Path(raw_path)
+        if not resolved.exists():
+            msg = f"Dataset '{cfg.label}': file not found for '{table_name}': {resolved}"
+            raise FileNotFoundError(msg)
+        t0 = time.perf_counter()
+        if table_name == "dist_skim":
+            lf = read_skim(resolved)
+            log.info("Read skim %s (%.1fs)", resolved.name, time.perf_counter() - t0)
+        else:
+            log.info("Scanning %s: %s", table_name, resolved)
+            lf = scan_csv(resolved)
+
+        # Apply column renames for this format + table
+        col_map = format_maps.get(table_name, {})
+        if col_map:
+            existing = set(lf.collect_schema().names())
+            rename = {k: v for k, v in col_map.items() if k in existing}
+            # Resolve conflicts: if multiple source cols map to same target,
+            # keep only the first match (col_map order = priority order).
+            seen_targets: dict = {}
+            drop_cols = []
+            for src, tgt in list(rename.items()):
+                if tgt in seen_targets:
+                    # Duplicate target — drop this source column instead
+                    drop_cols.append(src)
+                    del rename[src]
+                else:
+                    seen_targets[tgt] = src
+            if drop_cols:
+                lf = lf.drop(drop_cols)
+            if rename:
+                lf = lf.rename(rename)
+
+        # ActivitySim-specific post-rename transforms
+        if fmt == "activitysim":
+            lf = _apply_asim_transforms(table_name, lf)
+
+        # Validate that table_name is a declared ModelBundle field
+        _known = {
+            "taz_data", "dist_skim", "persons", "households",
+            "wsloc_results", "ao_results", "cdap_results",
+            "indiv_tour_data", "joint_tour_data",
+            "indiv_trip_data", "joint_trip_data",
+        }
+        if table_name not in _known:
+            msg = (
+                f"Dataset '{cfg.label}' has path key '{table_name}' which is not "
+                f"a recognized ModelBundle field. Known fields: {sorted(_known)}"
+            )
+            raise ValueError(msg)
+        setattr(bundle, table_name, lf)
+
+    # Post-load: merge WFH from persons onto cdap_results if missing
+    if bundle.cdap_results is not None and bundle.persons is not None:
+        cdap_cols = set(bundle.cdap_results.collect_schema().names())
+        persons_cols = set(bundle.persons.collect_schema().names())
+        if "work_from_home" not in cdap_cols and "work_from_home" in persons_cols:
+            bundle.cdap_results = bundle.cdap_results.join(
+                bundle.persons.select("person_id", "work_from_home"),
+                on="person_id",
+                how="left",
+            )
+
+    # Post-load: merge WFH onto wsloc_results too, so the work-distance summary
+    # can split by work-from-home status. CTRAMP carries wfh only on personData
+    # (wfh_choice), not wsLocResults; ActivitySim final_persons already has it.
+    if bundle.wsloc_results is not None and bundle.persons is not None:
+        wsloc_cols = set(bundle.wsloc_results.collect_schema().names())
+        persons_cols = set(bundle.persons.collect_schema().names())
+        if "work_from_home" not in wsloc_cols and "work_from_home" in persons_cols:
+            bundle.wsloc_results = bundle.wsloc_results.join(
+                bundle.persons.select("person_id", "work_from_home"),
+                on="person_id",
+                how="left",
+            )
+
+    return bundle
+
+
+# ---------------------------------------------------------------------------
+# ActivitySim post-rename transforms
+# ---------------------------------------------------------------------------
+
+_PTYPE_TO_STUDENT_CAT: dict[int, str] = {
+    3: "College or higher",         # University student
+    6: "Grade or high school",      # Driving-age student
+    7: "Grade or high school",      # Non-driving-age student
+    # ptype 8 (preschool) excluded: CTRAMP labels them "Not student" even
+    # though they receive a SchoolLocation.  Omitting keeps comparison
+    # apples-to-apples.
+}
+
+
+def _apply_asim_transforms(table_name: str, lf: pl.LazyFrame) -> pl.LazyFrame:
+    """Convert ActivitySim-specific values to canonical after column renames."""
+    cols = set(lf.collect_schema().names())
+
+    if table_name == "cdap_results":
+        # ptype int → string label for CDAP
+        if "ptype" in cols:
+            lf = lf.with_columns(
+                pl.col("ptype")
+                .replace_strict(PTYPE_LABELS, default="Unknown")
+                .alias("person_type"),
+            )
+
+    elif table_name == "wsloc_results":
+        # Prefer assigned_workplace_zone_id (post-WFH); fall back to
+        # workplace_zone_id for pre-WFH stages where the assigned col
+        # doesn't exist yet.
+        if "work_location" not in cols and "_workplace_zone_id_raw" in cols:
+            lf = lf.rename({"_workplace_zone_id_raw": "work_location"})
+        elif "_workplace_zone_id_raw" in cols:
+            lf = lf.drop("_workplace_zone_id_raw")
+        # Derive student_category from ptype
+        if "ptype" in cols:
+            lf = lf.with_columns(
+                pl.col("ptype")
+                .replace_strict(_PTYPE_TO_STUDENT_CAT, default=None)
+                .alias("student_category"),
+            )
+
+    elif table_name == "indiv_tour_data":
+        # Filter to non-joint tours only
+        if "tour_category" in cols:
+            lf = lf.filter(pl.col("tour_category") != "joint")
+            # Prefix at-work subtour purposes to match CTRAMP convention
+            # (CTRAMP: "atwork_business"; ASim: tour_type="business" + tour_category="atwork")
+            if "tour_purpose" in cols:
+                lf = lf.with_columns(
+                    pl.when(pl.col("tour_category") == "atwork")
+                    .then(pl.lit("atwork_") + pl.col("tour_purpose"))
+                    .otherwise(pl.col("tour_purpose"))
+                    .alias("tour_purpose"),
+                )
+        if "tour_mode" in cols:
+            lf = lf.with_columns(
+                pl.col("tour_mode")
+                .replace_strict(MODE_TO_INT, default=0)
+                .cast(pl.Int64),
+            )
+
+    elif table_name == "joint_tour_data":
+        # Filter to joint tours only
+        if "tour_category" in cols:
+            lf = lf.filter(pl.col("tour_category") == "joint")
+        if "tour_mode" in cols:
+            lf = lf.with_columns(
+                pl.col("tour_mode")
+                .replace_strict(MODE_TO_INT, default=0)
+                .cast(pl.Int64),
+            )
+        # Rename number_of_participants → num_participants for submodel compat
+        if "number_of_participants" in cols:
+            lf = lf.rename({"number_of_participants": "num_participants"})
+
+    elif table_name in ("indiv_trip_data", "joint_trip_data"):
+        if "trip_mode" in cols:
+            lf = lf.with_columns(
+                pl.col("trip_mode")
+                .replace_strict(MODE_TO_INT, default=0)
+                .cast(pl.Int64),
+            )
+
+    return lf

--- a/src/tm1/steps/summaries/calibration/report/__init__.py
+++ b/src/tm1/steps/summaries/calibration/report/__init__.py
@@ -1,0 +1,117 @@
+"""Calibration HTML report generation.
+
+Public API::
+
+    from tm1.steps.summaries.calibration.report import write_report
+    write_report(all_results, output_dir)
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import polars as pl
+
+from . import ao, atwork, cdap, commute_flows, nwdc, tour_mode, trip_mode, wfh, wsloc
+from .helpers import esc, load_template
+
+# (submodel_key, tab_title, render_function)
+_RENDERERS: list[tuple[str, str, object]] = [
+    ("daily_activity_pattern", "Daily Activity Pattern", cdap.render),
+    ("auto_ownership", "Auto Ownership", ao.render),
+    ("work_from_home", "Work From Home", wfh.render),
+    ("work_school_location", "Work / School Location", wsloc.render),
+    ("work_school_location", "Commuting Flows", commute_flows.render),
+    ("nonwork_dest_choice", "Non-Work Dest Choice", nwdc.render),
+    ("tour_mode_choice", "Tour Mode Choice", tour_mode.render),
+    ("atwork_subtour", "At-Work Subtours", atwork.render),
+    ("trip_mode_choice", "Trip Mode Choice", trip_mode.render),
+]
+
+
+def write_report(
+    all_results: dict[str, dict[str, dict[str, pl.DataFrame]]],
+    output_dir: Path,
+    *,
+    survey_labels: set[str] | None = None,
+    report_name: str = "calibration_report.html",
+    notes: str = "",
+) -> Path:
+    """Write calibration report HTML to *output_dir* and return the path."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    labels = list(all_results)
+    tabs: list[tuple[str, str]] = []
+
+    for submodel_key, title, renderer in _RENDERERS:
+        per_label = {
+            label: all_results[label].get(submodel_key, {})
+            for label in labels
+        }
+        if any(per_label.values()):
+            import inspect  # noqa: PLC0415
+
+            sig = inspect.signature(renderer)
+            if "survey_labels" in sig.parameters:
+                tabs.append((
+                    title,
+                    renderer(per_label, labels, survey_labels=survey_labels),
+                ))
+            else:
+                tabs.append((title, renderer(per_label, labels)))
+
+    dest = output_dir / report_name
+    if not tabs:
+        return dest
+
+    timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M UTC")
+
+    # --- Global dataset toggle bar (only if 3+ datasets) ---
+    dataset_bar = ""
+    if len(labels) >= 3:  # noqa: PLR2004
+        buttons = []
+        for i, label in enumerate(labels):
+            active = " active" if i in (1, 2) else ""
+            buttons.append(
+                f"<button class='ds-btn{active}' data-idx='{i}' "
+                f"onclick='toggleDS({i})'>{esc(label)}</button>"
+            )
+        dataset_bar = "<div class='ds-bar'>" + "\n".join(buttons) + "</div>"
+    default_pair = "1, 2"
+
+    # --- Tab buttons + panes ---
+    tab_buttons = ""
+    tab_panes = ""
+    for i, (title, content) in enumerate(tabs):
+        active = " active" if i == 0 else ""
+        display = "block" if i == 0 else "none"
+        tab_id = f"tab{i}"
+        tab_buttons += (
+            f"<button class='tab-btn{active}' "
+            f"onclick='showTab(\"{tab_id}\")'>"
+            f"{esc(title)}</button>\n"
+        )
+        tab_panes += (
+            f"<div id='{tab_id}' class='tab-pane' "
+            f"style='display:{display}'>\n{content}\n</div>\n"
+        )
+
+    page_tmpl = load_template("page.html")
+    notes_banner = ""
+    if notes:
+        notes_banner = (
+            "<div style='background:#fff3cd;border:1px solid #ffc107;"
+            "border-radius:4px;padding:10px 14px;margin:8px 0;"
+            "font-size:0.9em;color:#664d03;'>"
+            f"&#9432; {esc(notes.strip())}</div>"
+        )
+    html_str = page_tmpl.substitute(
+        timestamp=timestamp,
+        notes_banner=notes_banner,
+        dataset_bar=dataset_bar,
+        default_pair=default_pair,
+        tab_buttons=tab_buttons,
+        tab_panes=tab_panes,
+    )
+    dest.write_text(html_str, encoding="utf-8")
+    return dest

--- a/src/tm1/steps/summaries/calibration/report/ao.py
+++ b/src/tm1/steps/summaries/calibration/report/ao.py
@@ -1,0 +1,209 @@
+"""Auto Ownership tab renderer."""
+
+import polars as pl
+
+from .helpers import (
+    add_shares,
+    append_overall_fit,
+    compute_fit_row,
+    esc,
+    esc_js,
+    fit_table,
+    load_template,
+    pick_datasets,
+    pp_delta_cell,
+    render_pairs,
+    wrap_chart,
+)
+
+
+def render(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+) -> str:
+    datasets = pick_datasets(per_label, labels, "county_summary")
+    if len(datasets) < 2:  # noqa: PLR2004
+        return "<p>Need at least two datasets for comparison.</p>"
+
+    # N-way chart (always visible, not pair-toggled)
+    chart_html = _nway_chart(datasets)
+    # Pair-toggled tables
+    tables_html = render_pairs(datasets, _render_pair)
+
+    return (
+        "<div style='display:grid;grid-template-columns:max-content 1fr;"
+        "gap:1rem;align-items:start;'>"
+        f"<div>{tables_html}</div>"
+        f"<div>{chart_html}</div>"
+        "</div>"
+    )
+
+
+def _render_pair(
+    obs_label: str,
+    obs: pl.DataFrame,
+    mod_label: str,
+    mod: pl.DataFrame,
+) -> str:
+    county_col = "county_name" if "county_name" in obs.columns else obs.columns[0]
+    veh_cols = _union_veh_cols(obs, mod)
+    obs, mod = _fill_missing(obs, mod, veh_cols=veh_cols)
+
+    parts: list[str] = [
+        "<h3>County &times; Auto Ownership</h3>",
+        _comparison_table(obs, mod, obs_label, mod_label, county_col, veh_cols),
+        "<h3>Goodness of Fit</h3>",
+        _ao_fit_table(obs, mod, county_col, veh_cols),
+    ]
+    return "\n".join(parts)
+
+
+def _union_veh_cols(*frames: pl.DataFrame) -> list[str]:
+    non_veh = {"county", "county_name", "_total"}
+    cols: set[str] = set()
+    for df in frames:
+        cols.update(c for c in df.columns if c not in non_veh and not c.endswith("_share"))
+    return sorted(cols, key=lambda x: (int(x) if x.isdigit() else float("inf"), x))
+
+
+def _fill_missing(*frames: pl.DataFrame, veh_cols: list[str]) -> tuple[pl.DataFrame, ...]:
+    out: list[pl.DataFrame] = []
+    for df in frames:
+        for vc in veh_cols:
+            if vc not in df.columns:
+                df = df.with_columns(pl.lit(0).alias(vc))
+        out.append(df)
+    return tuple(out)
+
+
+def _comparison_table(
+    obs: pl.DataFrame, mod: pl.DataFrame,
+    obs_label: str, mod_label: str,
+    county_col: str, veh_cols: list[str],
+) -> str:
+    obs = add_shares(obs, veh_cols)
+    mod = add_shares(mod, veh_cols)
+
+    obs_rows = obs.sort(county_col).to_dicts()
+    mod_by_county: dict[str, dict] = {
+        r[county_col]: r for r in mod.sort(county_col).to_dicts()
+    }
+
+    header = (
+        "<table class='cal-table' style='width:auto;table-layout:auto;'>"
+        "<thead><tr>"
+        "<th>County</th><th>HH Vehicles</th>"
+        f"<th>{esc(obs_label)}</th>"
+        f"<th>{esc(mod_label)}</th>"
+        "<th>Delta (pp)</th>"
+        "</tr></thead><tbody>"
+    )
+    body = ""
+    for row in obs_rows:
+        county_name = row[county_col]
+        mr = mod_by_county.get(county_name, {})
+        first = True
+        for vc in veh_cols:
+            o = row.get(f"{vc}_share", 0) or 0
+            m = mr.get(f"{vc}_share", 0) or 0
+            p_cell = (
+                f"<td rowspan='{len(veh_cols)}'>{esc(str(county_name))}</td>"
+                if first else ""
+            )
+            body += (
+                f"<tr>{p_cell}<td style='text-align:center'>{esc(vc)}</td>"
+                f"<td>{o:.1%}</td><td>{m:.1%}</td>"
+                f"{pp_delta_cell(o, m)}</tr>"
+            )
+            first = False
+
+    return header + body + "</tbody></table>"
+
+
+def _ao_fit_table(
+    obs: pl.DataFrame, mod: pl.DataFrame,
+    county_col: str, veh_cols: list[str],
+) -> str:
+    obs_s = add_shares(obs, veh_cols).sort(county_col)
+    mod_s = add_shares(mod, veh_cols).sort(county_col)
+    obs_rows = obs_s.to_dicts()
+    mod_by_c = {r[county_col]: r for r in mod_s.to_dicts()}
+
+    fit_rows: list[dict] = []
+    for row in obs_rows:
+        county = row[county_col]
+        mr = mod_by_c.get(county, {})
+        obs_sh = [row.get(f"{vc}_share", 0) or 0 for vc in veh_cols]
+        mod_sh = [mr.get(f"{vc}_share", 0) or 0 for vc in veh_cols]
+        fit_rows.append(compute_fit_row(obs_sh, mod_sh, str(county)))
+
+    append_overall_fit(fit_rows)
+    return fit_table(fit_rows)
+
+
+_BLUE_LO = (198, 219, 239)
+_BLUE_HI = (8, 81, 156)
+
+
+def _seq_palette(n: int) -> list[str]:
+    if n == 1:
+        return ["#3182bd"]
+    return [
+        "#{:02x}{:02x}{:02x}".format(
+            *(
+                int(_BLUE_LO[c] + (_BLUE_HI[c] - _BLUE_LO[c]) * i / (n - 1))
+                for c in range(3)
+            ),
+        )
+        for i in range(n)
+    ]
+
+
+def _nway_chart(datasets: list[tuple[int, str, pl.DataFrame]]) -> str:
+    all_frames = [df for _, _, df in datasets]
+    veh_cols = _union_veh_cols(*all_frames)
+    filled = _fill_missing(*all_frames, veh_cols=veh_cols)
+
+    county_col = "county_name" if "county_name" in all_frames[0].columns else all_frames[0].columns[0]
+
+    ds_shares: list[tuple[str, pl.DataFrame]] = []
+    for (_idx, label, _raw), df in zip(datasets, filled, strict=True):
+        ds_shares.append((label, add_shares(df, veh_cols).sort(county_col, descending=True)))
+
+    counties = ds_shares[0][1][county_col].to_list()
+    ao_colours = _seq_palette(len(veh_cols))
+
+    y_labels: list[str] = []
+    spacer_idx = 0
+    for ci, county in enumerate(counties):
+        if ci > 0:
+            spacer_idx += 1
+            y_labels.append(" " * spacer_idx)
+        for label, _ in reversed(ds_shares):
+            y_labels.append(f"{county} ({esc(label)})")
+
+    traces: list[str] = []
+    for vi, vc in enumerate(veh_cols):
+        colour = ao_colours[vi]
+        x_vals: list[float] = []
+        for ci in range(len(counties)):
+            if ci > 0:
+                x_vals.append(0)
+            for _label, sdf in reversed(ds_shares):
+                x_vals.append(sdf[f"{vc}_share"][ci])
+        hover = [f"{vc}: {v:.1%}" if v > 0 else "" for v in x_vals]
+        traces.append(
+            f"{{name:'{esc_js(vc)}', "
+            f"y:{y_labels!r}, x:{x_vals!r}, type:'bar', "
+            f"orientation:'h', "
+            f"hovertext:{hover!r}, hoverinfo:'text+name', "
+            f"textposition:'none', "
+            f"marker:{{color:'{colour}'}}}}",
+        )
+
+    chart_id = "ao_chart_nway"
+    n_ds = len(ds_shares)
+    chart_height = max(400, len(counties) * (35 * n_ds + 25) + 100)
+    tmpl = load_template("ao_chart.js")
+    js = tmpl.substitute(div_id=chart_id, traces=", ".join(traces))
+    return wrap_chart(chart_id, js, width="100%", height=chart_height)

--- a/src/tm1/steps/summaries/calibration/report/atwork.py
+++ b/src/tm1/steps/summaries/calibration/report/atwork.py
@@ -1,0 +1,185 @@
+"""At-Work Subtour tab renderer — TLFD + mode shares in a compact tab."""
+
+import json
+
+import polars as pl
+
+from .helpers import (
+    MODE_COLOURS,
+    MODE_GROUPS,
+    append_overall_fit,
+    compute_fit_row,
+    esc,
+    esc_js,
+    fit_table,
+    normalise_shares,
+    pick_datasets,
+    pp_delta_cell,
+    render_pairs,
+    tlfd_traces_nway,
+    wrap_chart,
+)
+
+
+def render(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+    *,
+    survey_labels: set[str] | None = None,
+) -> str:
+    parts: list[str] = []
+
+    # --- TLFD section ---
+    tlfd_datasets = pick_datasets(per_label, labels, "atwork_tlfd")
+    if len(tlfd_datasets) >= 2:  # noqa: PLR2004
+        _bins, traces = tlfd_traces_nway(tlfd_datasets, survey_labels=survey_labels)
+        fit_rows: list[dict] = []
+        _idx0, _lbl0, ref_df = tlfd_datasets[0]
+        _rb, ref_share, _rs = normalise_shares(ref_df)
+        for _idx_m, mod_label, mod_df in tlfd_datasets[1:]:
+            _mb, mod_share, _ms = normalise_shares(mod_df)
+            fit_rows.append(compute_fit_row(ref_share, mod_share, mod_label))
+
+        parts.append("<h3>At-Work Subtour Trip Length Distribution</h3>")
+        div_id = "atwork_tlfd_chart"
+        js = (
+            f"Plotly.newPlot('{div_id}', {json.dumps(traces)}, {{"
+            f"title:'At-Work Subtour TLFD', "
+            f"xaxis:{{title:'Distance (miles)', dtick:5}}, "
+            f"yaxis:{{title:'Share', tickformat:'.1%'}}, "
+            f"legend:{{orientation:'h', y:-0.15, x:0.5, xanchor:'center'}}"
+            f"}});"
+        )
+        parts.append(wrap_chart(div_id, js))
+
+        # Fit + avg trip length side-by-side
+        avg_datasets = pick_datasets(per_label, labels, "atwork_avg_trip_length")
+        parts.append(
+            "<div style='display:flex;gap:24px;flex-wrap:wrap;align-items:start;'>",
+        )
+        if len(avg_datasets) >= 2:  # noqa: PLR2004
+            parts.append("<div><h3>Average Trip Length (miles)</h3>")
+            parts.append(render_pairs(avg_datasets, _render_avg_pair))
+            parts.append("</div>")
+        if fit_rows:
+            append_overall_fit(fit_rows)
+            parts.append("<div><h3>Goodness of Fit — Trip Length</h3>")
+            parts.append(fit_table(fit_rows))
+            parts.append("</div>")
+        parts.append("</div>")
+
+    # --- Mode share section ---
+    mode_datasets = pick_datasets(per_label, labels, "atwork_mode_summary")
+    if len(mode_datasets) >= 2:  # noqa: PLR2004
+        parts.append("<h3>At-Work Subtour Mode Shares</h3>")
+        parts.append(render_pairs(mode_datasets, _render_mode_pair))
+
+    if not parts:
+        msg = (
+            "At-Work Subtours renderer called but no data found. "
+            "Expected atwork_tlfd and atwork_mode_summary in results."
+        )
+        raise RuntimeError(msg)
+    return "\n".join(parts)
+
+
+def _render_avg_pair(
+    obs_label: str,
+    obs: pl.DataFrame,
+    mod_label: str,
+    mod: pl.DataFrame,
+) -> str:
+    obs_avg = obs["avg_trip_length"][0] if obs.height > 0 else 0.0
+    mod_avg = mod["avg_trip_length"][0] if mod.height > 0 else 0.0
+    delta = mod_avg - obs_avg
+    pct = (delta / obs_avg * 100) if obs_avg else 0.0
+    colour = "green" if abs(pct) < 5 else ("orange" if abs(pct) < 10 else "red")
+    return (
+        f"<table class='cal-table'><thead><tr>"
+        f"<th>{esc(obs_label)}</th><th>{esc(mod_label)}</th><th>Diff</th><th>% Diff</th>"
+        f"</tr></thead><tbody><tr>"
+        f"<td>{obs_avg:.2f}</td><td>{mod_avg:.2f}</td>"
+        f"<td>{delta:+.2f}</td>"
+        f"<td style='color:{colour}'>{pct:+.1f}%</td>"
+        f"</tr></tbody></table>"
+    )
+
+
+def _render_mode_pair(
+    obs_label: str,
+    obs: pl.DataFrame,
+    mod_label: str,
+    mod: pl.DataFrame,
+) -> str:
+    parts: list[str] = []
+
+    # Group modes
+    obs_g = _group_modes(obs)
+    mod_g = _group_modes(mod)
+
+    obs_total = obs_g["num_tours"].sum()
+    mod_total = mod_g["num_tours"].sum()
+
+    obs_lookup = {r["mode_group"]: r["num_tours"] for r in obs_g.to_dicts()}
+    mod_lookup = {r["mode_group"]: r["num_tours"] for r in mod_g.to_dicts()}
+
+    mode_groups = list(MODE_GROUPS)
+
+    header = (
+        "<table class='cal-table'><thead><tr>"
+        "<th>Mode</th>"
+        f"<th>{esc(obs_label)}</th><th>{esc(mod_label)}</th><th>Delta (pp)</th>"
+        "</tr></thead><tbody>"
+    )
+    body = ""
+    for mg in mode_groups:
+        o = (obs_lookup.get(mg, 0) / obs_total) if obs_total else 0.0
+        m = (mod_lookup.get(mg, 0) / mod_total) if mod_total else 0.0
+        body += (
+            f"<tr><td>{esc(mg)}</td>"
+            f"<td>{o:.1%}</td><td>{m:.1%}</td>"
+            f"{pp_delta_cell(o, m)}</tr>"
+        )
+    parts.append(header + body + "</tbody></table>")
+
+    # Bar chart
+    chart_id = f"atwork_mode_{obs_label}_{mod_label}".replace(" ", "_")
+    x_labels = mode_groups
+    obs_vals = [(obs_lookup.get(mg, 0) / obs_total) if obs_total else 0.0 for mg in mode_groups]
+    mod_vals = [(mod_lookup.get(mg, 0) / mod_total) if mod_total else 0.0 for mg in mode_groups]
+
+    colours = MODE_COLOURS
+    traces = [
+        f"{{name:'{esc_js(obs_label)}', x:{json.dumps(x_labels)}, y:{obs_vals!r}, "
+        f"type:'bar', marker:{{color:'{colours[0]}'}}}}" ,
+        f"{{name:'{esc_js(mod_label)}', x:{json.dumps(x_labels)}, y:{mod_vals!r}, "
+        f"type:'bar', marker:{{color:'{colours[1]}'}}}}" ,
+    ]
+    js = (
+        f"Plotly.newPlot('{chart_id}', [{', '.join(traces)}], {{"
+        f"barmode:'group', "
+        f"title:'At-Work Subtour Mode Shares', "
+        f"yaxis:{{tickformat:'.0%', title:'Share'}}, "
+        f"legend:{{orientation:'h', y:-0.15, x:0.5, xanchor:'center'}}"
+        f"}});"
+    )
+    parts.append(wrap_chart(chart_id, js, height=350))
+
+    return "\n".join(parts)
+
+
+def _group_modes(df: pl.DataFrame) -> pl.DataFrame:
+    mode_map: dict[int, str] = {}
+    for group_name, modes in MODE_GROUPS.items():
+        for m in modes:
+            mode_map[m] = group_name
+    return (
+        df.with_columns(
+            pl.col("tour_mode")
+            .replace_strict(mode_map, default="Other")
+            .alias("mode_group"),
+        )
+        .group_by("mode_group")
+        .agg(pl.col("num_tours").sum())
+        .sort("mode_group")
+    )

--- a/src/tm1/steps/summaries/calibration/report/cdap.py
+++ b/src/tm1/steps/summaries/calibration/report/cdap.py
@@ -1,0 +1,231 @@
+"""Daily Activity Pattern (CDAP) tab renderer."""
+
+import polars as pl
+
+from tm1.steps.summaries.calibration.enums import CTRAMPPersonType
+
+from .helpers import (
+    add_shares,
+    append_overall_fit,
+    compute_fit_row,
+    count_cell,
+    esc,
+    esc_js,
+    fit_table,
+    load_template,
+    pct_cell,
+    pick_datasets,
+    pp_delta_cell,
+    render_pairs,
+    wrap_chart,
+)
+
+PERSON_TYPE_LABELS: dict[int, str] = {pt.id: pt.label for pt in CTRAMPPersonType}
+
+PATTERNS = ["H", "M", "N"]
+PATTERN_COLOURS = {"H": "#76b7b2", "M": "#4e79a7", "N": "#f28e2b"}
+
+_NEAR_ZERO = 1e-9
+
+_COLGROUP = (
+    "<colgroup>"
+    "<col style='width:190px'>"
+    + "<col style='width:90px'>" * 9
+    + "</colgroup>"
+)
+
+
+def render(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+) -> str:
+    datasets = pick_datasets(per_label, labels, "person_type_summary")
+    if len(datasets) < 2:  # noqa: PLR2004
+        return "<p>Need at least two datasets for comparison.</p>"
+    return render_pairs(datasets, _render_pair)
+
+
+def _render_pair(
+    obs_label: str,
+    obs_raw: pl.DataFrame,
+    mod_label: str,
+    mod_raw: pl.DataFrame,
+) -> str:
+    obs = add_shares(_label_person_types(obs_raw), PATTERNS)
+    mod = add_shares(_label_person_types(mod_raw), PATTERNS)
+
+    chart_id = f"cdap_{obs_label}_{mod_label}".replace(" ", "_")
+    parts: list[str] = [
+        "<h3>Share Comparison</h3>",
+        _shares_table(obs, mod, obs_label, mod_label),
+        "<h3>Absolute Counts</h3>",
+        _counts_table(obs, mod, obs_label, mod_label),
+        "<h3>Goodness of Fit</h3>",
+        _fit_section(obs, mod),
+        _chart(obs, mod, obs_label, mod_label, chart_id),
+    ]
+    return "\n".join(parts)
+
+
+def _label_person_types(df: pl.DataFrame) -> pl.DataFrame:
+    return df.with_columns(
+        pl.col("person_type").cast(pl.Int64)
+        .replace_strict(PERSON_TYPE_LABELS, default="Unknown")
+        .alias("person_type_label"),
+    )
+
+
+def _pt_label(row: dict) -> str:
+    return esc(row.get("person_type_label", str(row["person_type"])))
+
+
+def _two_row_header(obs_label: str, mod_label: str, third_label: str) -> str:
+    ncols = len(PATTERNS)
+    h = "<thead><tr><th rowspan='2'>Person Type</th>"
+    h += f"<th colspan='{ncols}' class='group-sep'>{esc(obs_label)}</th>"
+    h += f"<th colspan='{ncols}' class='group-sep'>{esc(mod_label)}</th>"
+    h += f"<th colspan='{ncols}' class='group-sep'>{third_label}</th>"
+    h += "</tr><tr>"
+    for g in range(3):
+        for p in PATTERNS:
+            cls = " class='group-sep'" if g > 0 and p == PATTERNS[0] else ""
+            h += f"<th{cls}>{p}</th>"
+    h += "</tr></thead>"
+    return h
+
+
+def _open_table() -> str:
+    return f"<table class='cal-table'>{_COLGROUP}"
+
+
+def _counts_table(obs: pl.DataFrame, mod: pl.DataFrame, obs_label: str, mod_label: str) -> str:
+    rows_obs = obs.sort("person_type").to_dicts()
+    mod_by_pt = {r["person_type"]: r for r in mod.sort("person_type").to_dicts()}
+
+    out = _open_table()
+    out += _two_row_header(obs_label, mod_label, "Delta (pp)")
+    out += "<tbody>"
+
+    for row in rows_obs:
+        mr = mod_by_pt.get(row["person_type"], {})
+        out += f"<tr><td>{_pt_label(row)}</td>"
+        for p in PATTERNS:
+            out += count_cell(row.get(p))
+        for i, p in enumerate(PATTERNS):
+            cls = " class='group-sep'" if i == 0 else ""
+            val = mr.get(p)
+            out += f"<td{cls}>{val:,.0f}</td>" if val is not None else f"<td{cls}>—</td>"
+        # Delta column: use share-based pp difference (less sensitive than % change on counts)
+        for i, p in enumerate(PATTERNS):
+            obs_share = row.get(f"{p}_share", 0) or 0
+            mod_share = mr.get(f"{p}_share", 0) or 0
+            if i == 0:
+                diff = (mod_share - obs_share) * 100
+                mag = abs(diff)
+                cls = "group-sep"
+                if mag > 10:
+                    cls += " err-bad"
+                elif mag > 5:
+                    cls += " err-warn"
+                sign = "+" if diff >= 0 else ""
+                out += f"<td class='{cls}'>{sign}{diff:.1f} pp</td>"
+            else:
+                out += pp_delta_cell(obs_share, mod_share)
+        out += "</tr>"
+    return out + "</tbody></table>"
+
+
+def _shares_table(obs: pl.DataFrame, mod: pl.DataFrame, obs_label: str, mod_label: str) -> str:
+    rows_obs = obs.sort("person_type").to_dicts()
+    mod_by_pt = {r["person_type"]: r for r in mod.sort("person_type").to_dicts()}
+
+    out = _open_table()
+    out += _two_row_header(f"{obs_label} (Share)", f"{mod_label} (Share)", "Delta (pp)")
+    out += "<tbody>"
+
+    for row in rows_obs:
+        mr = mod_by_pt.get(row["person_type"], {})
+        out += f"<tr><td>{_pt_label(row)}</td>"
+        for p in PATTERNS:
+            out += pct_cell(row.get(f"{p}_share"))
+        for i, p in enumerate(PATTERNS):
+            cls = " class='group-sep'" if i == 0 else ""
+            val = mr.get(f"{p}_share")
+            out += f"<td{cls}>{val:.1%}</td>" if val is not None else f"<td{cls}>—</td>"
+        for i, p in enumerate(PATTERNS):
+            obs_val = row.get(f"{p}_share", 0) or 0
+            mod_val = mr.get(f"{p}_share", 0) or 0
+            if i == 0:
+                # First delta col needs group-sep — build cell manually
+                diff = (mod_val - obs_val) * 100
+                mag = abs(diff)
+                cls = "group-sep"
+                if mag > 10:
+                    cls += " err-bad"
+                elif mag > 5:
+                    cls += " err-warn"
+                sign = "+" if diff >= 0 else ""
+                out += f"<td class='{cls}'>{sign}{diff:.1f} pp</td>"
+            else:
+                out += pp_delta_cell(obs_val, mod_val)
+        out += "</tr>"
+    return out + "</tbody></table>"
+
+
+
+
+
+def _fit_section(obs: pl.DataFrame, mod: pl.DataFrame) -> str:
+    rows_obs = obs.sort("person_type").to_dicts()
+    mod_by_pt = {r["person_type"]: r for r in mod.sort("person_type").to_dicts()}
+
+    fit_rows: list[dict] = []
+    for row in rows_obs:
+        mr = mod_by_pt.get(row["person_type"], {})
+        obs_shares = [row.get(f"{p}_share", 0) or 0 for p in PATTERNS]
+        mod_shares = [mr.get(f"{p}_share", 0) or 0 for p in PATTERNS]
+        fit_rows.append(compute_fit_row(obs_shares, mod_shares, _pt_label(row)))
+
+    append_overall_fit(fit_rows)
+    return fit_table(fit_rows)
+
+
+def _chart(
+    obs: pl.DataFrame, mod: pl.DataFrame,
+    obs_label: str, mod_label: str, chart_id: str,
+) -> str:
+    # Use a canonical set of all person types present in either dataset
+    all_pts = sorted(
+        set(obs["person_type"].to_list()) | set(mod["person_type"].to_list())
+    )
+    pt_labels = [
+        PERSON_TYPE_LABELS.get(pt, f"Type {pt}") for pt in all_pts
+    ]
+
+    obs_by_pt = {r["person_type"]: r for r in obs.to_dicts()}
+    mod_by_pt = {r["person_type"]: r for r in mod.to_dicts()}
+
+    traces: list[str] = []
+    for p in PATTERNS:
+        colour = PATTERN_COLOURS[p]
+        for source, by_pt, opacity in [
+            (obs_label, obs_by_pt, 0.55),
+            (mod_label, mod_by_pt, 1.0),
+        ]:
+            shares = [by_pt.get(pt, {}).get(f"{p}_share", 0) or 0 for pt in all_pts]
+            counts = [by_pt.get(pt, {}).get(p, 0) or 0 for pt in all_pts]
+            hover = [
+                f"{p}: {s:.1%} ({c:,.0f})"
+                for s, c in zip(shares, counts, strict=True)
+            ]
+            traces.append(
+                f"{{name:'{p} ({esc_js(source)})', "
+                f"x:{pt_labels!r}, y:{shares!r}, type:'bar', "
+                f"hovertext:{hover!r}, hoverinfo:'text+name', "
+                f"textposition:'none', "
+                f"marker:{{color:'{colour}',opacity:{opacity}}}}}",
+            )
+
+    tmpl = load_template("cdap_chart.js")
+    js = tmpl.substitute(div_id=chart_id, traces=", ".join(traces))
+    return wrap_chart(chart_id, js)

--- a/src/tm1/steps/summaries/calibration/report/commute_flows.py
+++ b/src/tm1/steps/summaries/calibration/report/commute_flows.py
@@ -1,0 +1,192 @@
+"""County-to-County Commuting Flows tab renderer."""
+
+import json
+
+import polars as pl
+
+from tm1.steps.summaries.calibration.enums import CTRAMPCounty
+
+from .helpers import (
+    add_shares,
+    append_overall_fit,
+    compute_fit_row,
+    esc,
+    fit_table,
+    pct_cell,
+    pick_datasets,
+    pp_delta_cell,
+    render_pairs,
+)
+
+_COUNTY_NAMES = [c.label for c in CTRAMPCounty]
+
+
+def render(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+) -> str:
+    datasets = pick_datasets(per_label, labels, "county_summary")
+    if len(datasets) < 2:  # noqa: PLR2004
+        return "<p>Insufficient data for comparison.</p>"
+    return render_pairs(datasets, _render_pair)
+
+
+def _render_pair(
+    obs_label: str,
+    obs_df: pl.DataFrame,
+    mod_label: str,
+    mod_df: pl.DataFrame,
+) -> str:
+    parts: list[str] = [
+        _scatter_chart(obs_df, mod_df, obs_label, mod_label),
+        _flow_tables(obs_df, mod_df, obs_label, mod_label),
+        "<h3>Goodness of Fit</h3>",
+        _flows_fit_table(obs_df, mod_df),
+    ]
+    return "\n".join(parts)
+
+
+def _scatter_chart(
+    obs: pl.DataFrame, mod: pl.DataFrame,
+    obs_label: str, mod_label: str,
+) -> str:
+    """Scatter plot of observed vs modeled commute flow shares per county pair."""
+    county_col = "home_county_name"
+    value_cols = [c for c in _COUNTY_NAMES if c in obs.columns or c in mod.columns]
+
+    if not value_cols:
+        return ""
+
+    obs_s = add_shares(obs, value_cols)
+    mod_s = add_shares(mod, value_cols)
+    mod_by_hc = {r[county_col]: r for r in mod_s.to_dicts()}
+
+    x_vals: list[float] = []
+    y_vals: list[float] = []
+    hover: list[str] = []
+
+    for row in obs_s.to_dicts():
+        hc = row[county_col]
+        mr = mod_by_hc.get(hc, {})
+        for vc in value_cols:
+            obs_val = row.get(f"{vc}_share", 0) or 0
+            mod_val = mr.get(f"{vc}_share", 0) or 0
+            x_vals.append(round(obs_val * 100, 3))
+            y_vals.append(round(mod_val * 100, 3))
+            hover.append(f"{hc} → {vc}")
+
+    if not x_vals:
+        return ""
+
+    # Diagonal reference line
+    max_val = max(max(x_vals, default=1), max(y_vals, default=1))
+    traces = [
+        {
+            "x": [0, max_val],
+            "y": [0, max_val],
+            "mode": "lines",
+            "line": {"dash": "dash", "color": "#999", "width": 1},
+            "showlegend": False,
+            "hoverinfo": "skip",
+        },
+        {
+            "x": x_vals,
+            "y": y_vals,
+            "mode": "markers",
+            "marker": {"size": 7, "color": "#2196F3", "opacity": 0.7},
+            "text": hover,
+            "hovertemplate": "%{text}<br>Obs: %{x:.1f}%<br>Mod: %{y:.1f}%<extra></extra>",
+            "showlegend": False,
+        },
+    ]
+    layout = {
+        "title": {"text": "Commute Flow Shares: Observed vs Modeled", "font": {"size": 14}},
+        "xaxis": {"title": f"{obs_label} (%)", "rangemode": "tozero"},
+        "yaxis": {"title": f"{mod_label} (%)", "rangemode": "tozero", "scaleanchor": "x"},
+        "margin": {"l": 55, "r": 20, "t": 40, "b": 50},
+        "width": 520,
+        "height": 520,
+    }
+    div_id = "commute_scatter_" + "".join(c for c in f"{obs_label}_{mod_label}" if c.isalnum() or c == "_")
+    js = f"Plotly.newPlot('{div_id}', {json.dumps(traces)}, {json.dumps(layout)}, {{responsive:true}});"
+    return (
+        f"<h3>Observed vs Modeled Flow Shares</h3>"
+        f"<div id='{div_id}' style='width:540px;height:540px;margin:0 auto;'></div>"
+        f"<script>{js}</script>"
+    )
+
+
+def _flow_tables(
+    obs: pl.DataFrame, mod: pl.DataFrame,
+    obs_label: str, mod_label: str,
+) -> str:
+    county_col = "home_county_name"
+    value_cols = [c for c in _COUNTY_NAMES if c in obs.columns or c in mod.columns]
+
+    obs_s = add_shares(obs, value_cols)
+    mod_s = add_shares(mod, value_cols)
+
+    county_order = {name: i for i, name in enumerate(_COUNTY_NAMES)}
+    obs_rows = sorted(obs_s.to_dicts(), key=lambda r: county_order.get(r[county_col], 99))
+    mod_rows = sorted(mod_s.to_dicts(), key=lambda r: county_order.get(r[county_col], 99))
+    mod_by_hc: dict[str, dict] = {r[county_col]: r for r in mod_rows}
+
+    out = f"<h3>{esc(obs_label)} (Share)</h3>"
+    out += _matrix_html(obs_rows, county_col, value_cols)
+
+    out += f"<h3>{esc(mod_label)} (Share)</h3>"
+    out += _matrix_html(mod_rows, county_col, value_cols)
+
+    out += "<h3>Delta (pp)</h3>"
+    out += "<table class='cal-table'><thead><tr><th>Home County</th>"
+    for vc in value_cols:
+        out += f"<th>{esc(vc)}</th>"
+    out += "</tr></thead><tbody>"
+    for row in obs_rows:
+        hc = row[county_col]
+        mr = mod_by_hc.get(hc, {})
+        out += f"<tr><td>{esc(str(hc))}</td>"
+        for vc in value_cols:
+            obs_val = row.get(f"{vc}_share", 0) or 0
+            mod_val = mr.get(f"{vc}_share", 0) or 0
+            out += pp_delta_cell(obs_val, mod_val)
+        out += "</tr>"
+    out += "</tbody></table>"
+    return out
+
+
+def _matrix_html(rows: list[dict], county_col: str, value_cols: list[str]) -> str:
+    out = "<table class='cal-table'><thead><tr><th>Home County</th>"
+    for vc in value_cols:
+        out += f"<th>{esc(vc)}</th>"
+    out += "</tr></thead><tbody>"
+    for row in rows:
+        out += f"<tr><td>{esc(str(row[county_col]))}</td>"
+        for vc in value_cols:
+            out += pct_cell(row.get(f"{vc}_share"))
+        out += "</tr>"
+    out += "</tbody></table>"
+    return out
+
+
+def _flows_fit_table(obs: pl.DataFrame, mod: pl.DataFrame) -> str:
+    county_col = "home_county_name"
+    value_cols = [c for c in _COUNTY_NAMES if c in obs.columns or c in mod.columns]
+
+    obs_s = add_shares(obs, value_cols)
+    mod_s = add_shares(mod, value_cols)
+
+    county_order = {name: i for i, name in enumerate(_COUNTY_NAMES)}
+    obs_rows = sorted(obs_s.to_dicts(), key=lambda r: county_order.get(r[county_col], 99))
+    mod_by_hc = {r[county_col]: r for r in mod_s.to_dicts()}
+
+    fit_rows: list[dict] = []
+    for row in obs_rows:
+        hc = row[county_col]
+        mr = mod_by_hc.get(hc, {})
+        obs_sh = [row.get(f"{vc}_share", 0) or 0 for vc in value_cols]
+        mod_sh = [mr.get(f"{vc}_share", 0) or 0 for vc in value_cols]
+        fit_rows.append(compute_fit_row(obs_sh, mod_sh, str(hc)))
+
+    append_overall_fit(fit_rows)
+    return fit_table(fit_rows)

--- a/src/tm1/steps/summaries/calibration/report/helpers.py
+++ b/src/tm1/steps/summaries/calibration/report/helpers.py
@@ -1,0 +1,384 @@
+"""Shared formatting helpers for calibration report."""
+
+import html
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from string import Template
+
+import polars as pl
+
+from tm1.steps.summaries.calibration.enums import CTRAMPModeType
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+_NEAR_ZERO = 1e-9
+
+# ---------------------------------------------------------------------------
+# Mode groups for tour/trip charts — collapses 21 modes into 8 categories
+# ---------------------------------------------------------------------------
+M = CTRAMPModeType
+
+MODE_GROUPS: dict[str, list[int]] = {
+    "Drive Alone": [M.DA.id, M.DA_TOLL.id],
+    "Shared Ride 2": [M.SR2.id, M.SR2_TOLL.id],
+    "Shared Ride 3+": [M.SR3.id, M.SR3_TOLL.id],
+    "Walk": [M.WALK.id],
+    "Bike": [M.BIKE.id],
+    "Transit - Walk": [
+        M.WLK_LOC_WLK.id, M.WLK_LRF_WLK.id, M.WLK_EXP_WLK.id,
+        M.WLK_HVY_WLK.id, M.WLK_COM_WLK.id,
+    ],
+    "Transit - Drive": [
+        M.DRV_LOC_WLK.id, M.DRV_LRF_WLK.id, M.DRV_EXP_WLK.id,
+        M.DRV_HVY_WLK.id, M.DRV_COM_WLK.id,
+    ],
+    "Taxi/TNC": [M.TAXI.id, M.TNC.id, M.TNC2.id],
+}
+
+del M
+
+MODE_COLOURS = [
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#9467bd",
+    "#8c564b", "#e377c2", "#d62728", "#bcbd22",
+]
+
+DATASET_COLOURS = [
+    "#4e79a7", "#e15759", "#59a14f", "#f28e2b",
+    "#b07aa1", "#76b7b2", "#edc949",
+]
+
+
+# ---------------------------------------------------------------------------
+# Basic HTML helpers
+# ---------------------------------------------------------------------------
+
+def load_template(name: str) -> Template:
+    return Template((_TEMPLATES_DIR / name).read_text(encoding="utf-8"))
+
+
+def esc(s: str) -> str:
+    return html.escape(str(s))
+
+
+def esc_js(s: str) -> str:
+    """Escape for embedding in JS single-quoted strings."""
+    return str(s).replace("\\", "\\\\").replace("'", "\\'").replace('"', '\\"')
+
+
+# ---------------------------------------------------------------------------
+# Delta cells with colour coding
+# ---------------------------------------------------------------------------
+
+def pp_delta_cell(obs: float, mod: float) -> str:
+    """Percentage-point difference cell. obs/mod are shares (0-1 scale).
+    Displays as '+2.1 pp'. Highlights >5pp amber, >10pp pink."""
+    diff = (mod - obs) * 100  # share → pp
+    magnitude = abs(diff)
+    cls = ""
+    if magnitude > 10:
+        cls = " class='err-bad'"
+    elif magnitude > 5:
+        cls = " class='err-warn'"
+    sign = "+" if diff >= 0 else ""
+    return f"<td{cls}>{sign}{diff:.1f} pp</td>"
+
+
+def pct_change_cell(obs: float, mod: float) -> str:
+    """Percent-change cell for absolute values.
+    Displays as '+15.3%'. Highlights >5% amber, >10% pink."""
+    if abs(obs) < _NEAR_ZERO:
+        return "<td>—</td>"
+    diff = (mod - obs) / obs * 100
+    magnitude = abs(diff)
+    cls = ""
+    if magnitude > 10:
+        cls = " class='err-bad'"
+    elif magnitude > 5:
+        cls = " class='err-warn'"
+    sign = "+" if diff >= 0 else ""
+    return f"<td{cls}>{sign}{diff:.1f}%</td>"
+
+
+def pct_cell(val: float | None) -> str:
+    if val is None:
+        return "<td>—</td>"
+    return f"<td>{val:.1%}</td>"
+
+
+def count_cell(val: float | None) -> str:
+    if val is None:
+        return "<td>—</td>"
+    return f"<td>{val:,.0f}</td>"
+
+
+def rel_share_delta_cell(obs: float, mod: float, *, min_pp: float = 0.01) -> str:
+    """Relative share-difference cell for mode parity tables.
+
+    Flags amber > 10%, red > 50%. Differences under *min_pp* percentage points
+    are shown unflagged — relative error on a vanishing share is noise.
+    """
+    if abs(obs) < _NEAR_ZERO:
+        return "<td>—</td>"
+    diff = (mod - obs) / obs * 100
+    magnitude = abs(diff)
+    cls = ""
+    if abs(mod - obs) * 100 >= min_pp:
+        if magnitude > 50:
+            cls = " class='err-bad'"
+        elif magnitude > 10:
+            cls = " class='err-warn'"
+    sign = "+" if diff >= 0 else ""
+    return f"<td{cls}>{sign}{diff:.0f}%</td>"
+
+
+def mode_parity_table(
+    obs: pl.DataFrame,
+    mod: pl.DataFrame,
+    obs_label: str,
+    mod_label: str,
+    mode_col: str,
+    count_col: str,
+) -> str:
+    """Disaggregate (21-mode) share parity table across all purposes.
+
+    The grouped shares table flags percentage-point deltas, which cannot
+    surface a large relative error on a minor mode — a 3x over-prediction of
+    a 0.2%-share mode moves the grouped table by well under a point. This
+    table keeps every mode separate and flags relative differences.
+    """
+    def shares(df: pl.DataFrame) -> dict[int, float]:
+        g = df.group_by(mode_col).agg(pl.col(count_col).sum())
+        total = g[count_col].sum() or 1
+        return {r[mode_col]: r[count_col] / total for r in g.to_dicts()}
+
+    obs_shares = shares(obs)
+    mod_shares = shares(mod)
+
+    out = (
+        "<table class='cal-table'><thead><tr>"
+        f"<th>Mode</th><th>{esc(obs_label)}</th><th>{esc(mod_label)}</th>"
+        "<th>Delta (pp)</th><th>Delta (relative)</th>"
+        "</tr></thead><tbody>"
+    )
+    for m in CTRAMPModeType:
+        o = obs_shares.get(m.id, 0.0)
+        d = mod_shares.get(m.id, 0.0)
+        out += (
+            f"<tr><td>{esc(m.label)}</td>"
+            f"<td>{o:.2%}</td><td>{d:.2%}</td>"
+            f"{pp_delta_cell(o, d)}{rel_share_delta_cell(o, d)}</tr>"
+        )
+    out += "</tbody></table>"
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Dataset helpers
+# ---------------------------------------------------------------------------
+
+def pick_datasets(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+    table_key: str,
+) -> list[tuple[int, str, pl.DataFrame]]:
+    """Return (global_index, label, df) for labels that have *table_key*."""
+    return [
+        (i, label, per_label[label][table_key])
+        for i, label in enumerate(labels)
+        if table_key in per_label.get(label, {})
+    ]
+
+
+def add_shares(df: pl.DataFrame, value_cols: list[str]) -> pl.DataFrame:
+    """Add ``{col}_share`` columns normalised across *value_cols* per row."""
+    total = pl.sum_horizontal(*[pl.col(c) for c in value_cols]).alias("_total")
+    df = df.with_columns(total)
+    for c in value_cols:
+        df = df.with_columns(
+            (pl.col(c) / pl.col("_total")).alias(f"{c}_share"),
+        )
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Pair-section wrapper (global toggle pattern)
+# ---------------------------------------------------------------------------
+
+def render_pairs(
+    datasets: list[tuple[int, str, pl.DataFrame]],
+    render_pair,
+) -> str:
+    """Pre-render all C(N,2) pair sections with data-pair attributes.
+
+    Each dataset tuple is (global_index, label, df).
+    render_pair is called as render_pair(label_a, df_a, label_b, df_b).
+    """
+    n = len(datasets)
+    if n < 2:
+        return ""
+    if n == 2:
+        gi, gj = datasets[0][0], datasets[1][0]
+        key = f"{min(gi, gj)}_{max(gi, gj)}"
+        content = render_pair(
+            datasets[0][1], datasets[0][2],
+            datasets[1][1], datasets[1][2],
+        )
+        return f"<div class='pair-section' data-pair='{key}'>\n{content}\n</div>"
+    sections: list[str] = []
+    for a in range(n):
+        for b in range(a + 1, n):
+            gi, gj = datasets[a][0], datasets[b][0]
+            key = f"{min(gi, gj)}_{max(gi, gj)}"
+            display = "" if (a == 1 and b == 2) else "display:none"
+            content = render_pair(
+                datasets[a][1], datasets[a][2],
+                datasets[b][1], datasets[b][2],
+            )
+            sections.append(
+                f"<div class='pair-section' data-pair='{key}'"
+                f" style='{display}'>\n{content}\n</div>"
+            )
+    return "\n".join(sections)
+
+
+# ---------------------------------------------------------------------------
+# Plotly chart wrapper
+# ---------------------------------------------------------------------------
+
+def wrap_chart(
+    div_id: str, js_body: str, *, width: int | str = 900, height: int | str = 450,
+) -> str:
+    w = f"{width}px" if isinstance(width, int) else width
+    h = f"{height}px" if isinstance(height, int) else height
+    return (
+        f"<div id='{div_id}' style='width:{w};height:{h};'></div>\n"
+        f"<script>\n{js_body}\n</script>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fit metrics (NRMSE + Dissimilarity only)
+# ---------------------------------------------------------------------------
+
+def compute_fit_row(
+    obs_shares: Sequence[float],
+    mod_shares: Sequence[float],
+    label: str,
+) -> dict:
+    """Compute NRMSE and dissimilarity for one category/purpose."""
+    k = len(obs_shares)
+    sse = sum((m - o) ** 2 for o, m in zip(obs_shares, mod_shares, strict=True))
+    dissim_num = sum(abs(m - o) for o, m in zip(obs_shares, mod_shares, strict=True))
+    obs_range = max(obs_shares) - min(obs_shares) if obs_shares else 1.0
+    rmse = math.sqrt(sse / k) if k else 0.0
+    nrmse = rmse / obs_range if obs_range > _NEAR_ZERO else 0.0
+    return {
+        "label": label,
+        "nrmse": nrmse,
+        "dissim": dissim_num / 2,
+    }
+
+
+def fit_table(rows: list[dict]) -> str:
+    """Build NRMSE + Dissimilarity table with optional bold Overall row."""
+    out = "<table class='fit-table'><thead><tr>"
+    out += "<th></th><th>NRMSE</th><th>Dissimilarity</th>"
+    out += "</tr></thead><tbody>"
+    for row in rows:
+        bold = " style='font-weight:600;border-top:2px solid #333;'" if row.get("_bold") else ""
+        out += f"<tr{bold}><td>{esc(str(row['label']))}</td>"
+        out += f"<td>{row['nrmse']:.4f}</td>"
+        out += f"<td>{row['dissim']:.4f}</td></tr>"
+    out += "</tbody></table>"
+    return out
+
+
+def append_overall_fit(rows: list[dict]) -> None:
+    """Append bold 'Overall' average row in place."""
+    if not rows:
+        return
+    n = len(rows)
+    rows.append({
+        "label": "Overall",
+        "nrmse": sum(r["nrmse"] for r in rows) / n,
+        "dissim": sum(r["dissim"] for r in rows) / n,
+        "_bold": True,
+    })
+
+
+# ---------------------------------------------------------------------------
+# TLFD helpers
+# ---------------------------------------------------------------------------
+
+def gaussian_smooth(values: list[float], *, sigma: float = 2.0) -> list[float]:
+    n = len(values)
+    if n == 0:
+        return []
+    radius = int(math.ceil(3 * sigma))
+    kernel = [math.exp(-0.5 * (d / sigma) ** 2) for d in range(radius + 1)]
+    smoothed = []
+    for i in range(n):
+        wsum = 0.0
+        vsum = 0.0
+        for d in range(-radius, radius + 1):
+            j = i + d
+            if 0 <= j < n:
+                w = kernel[abs(d)]
+                wsum += w
+                vsum += w * values[j]
+        smoothed.append(vsum / wsum if wsum else 0.0)
+    return smoothed
+
+
+def normalise_shares(
+    df: pl.DataFrame, *, sigma: float = 2.0,
+) -> tuple[list, list[float], list[float]]:
+    """Compute normalised shares and smoothed curve from TLFD DataFrame."""
+    bins = df["distbin"].to_list()
+    total = df["Total"].to_list() if "Total" in df.columns else []
+    s = sum(total) or 1
+    share = [v / s for v in total]
+    smooth = gaussian_smooth(share, sigma=sigma)
+    return bins, share, smooth
+
+
+def tlfd_traces_nway(
+    datasets: list[tuple[int, str, pl.DataFrame]] | list[tuple[str, pl.DataFrame]],
+    *,
+    sigma: float = 2.0,
+    survey_labels: set[str] | None = None,
+) -> tuple[list, list[dict]]:
+    """Build Plotly trace dicts for an N-way TLFD comparison."""
+    traces: list[dict] = []
+    bins: list = []
+    for i, item in enumerate(datasets):
+        # Support both (idx, label, df) and (label, df) forms
+        if len(item) == 3:
+            _, label, df = item
+        else:
+            label, df = item
+        b, share, smooth = normalise_shares(df, sigma=sigma)
+        if i == 0:
+            bins = b
+        colour = DATASET_COLOURS[i % len(DATASET_COLOURS)]
+        is_survey = (
+            label in survey_labels if survey_labels is not None else i == 0
+        )
+        if is_survey:
+            traces.append({
+                "name": f"{label} (raw)", "x": b, "y": share,
+                "type": "scatter", "mode": "markers",
+                "marker": {"size": 3, "opacity": 0.4, "color": colour},
+            })
+            traces.append({
+                "name": f"{label} (smooth)", "x": b, "y": smooth,
+                "type": "scatter", "mode": "lines",
+                "line": {"width": 2, "color": colour},
+            })
+        else:
+            traces.append({
+                "name": label, "x": b, "y": share,
+                "type": "scatter", "mode": "lines",
+                "line": {"width": 2, "color": colour},
+            })
+    return bins, traces

--- a/src/tm1/steps/summaries/calibration/report/nwdc.py
+++ b/src/tm1/steps/summaries/calibration/report/nwdc.py
@@ -1,0 +1,145 @@
+"""Non-work Destination Choice tab renderer."""
+
+import json
+
+import polars as pl
+
+from .helpers import (
+    append_overall_fit,
+    compute_fit_row,
+    esc,
+    fit_table,
+    load_template,
+    normalise_shares,
+    pct_change_cell,
+    pick_datasets,
+    render_pairs,
+    tlfd_traces_nway,
+)
+
+
+def render(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+    *,
+    survey_labels: set[str] | None = None,
+) -> str:
+    parts: list[str] = []
+
+    purposes = [
+        ("nwdc_tlfd_escort", "Escort"),
+        ("nwdc_tlfd_shopping", "Shopping"),
+        ("nwdc_tlfd_maintenance", "Maintenance"),
+        ("nwdc_tlfd_eating_out", "Eating Out"),
+        ("nwdc_tlfd_visiting", "Visiting"),
+        ("nwdc_tlfd_discretionary", "Discretionary"),
+        ("nwdc_tlfd_atwork", "At-Work"),
+    ]
+
+    # --- TLFD grid: overlay all datasets on each purpose chart ---
+    fit_rows: list[dict] = []
+    grid_items: list[dict] = []
+
+    for tlfd_key, purpose_title in purposes:
+        datasets = pick_datasets(per_label, labels, tlfd_key)
+        if len(datasets) < 2:  # noqa: PLR2004
+            continue
+        _bins, traces = tlfd_traces_nway(datasets, survey_labels=survey_labels)
+        grid_items.append({
+            "div_id": f"nwdc_{tlfd_key}",
+            "title": purpose_title,
+            "traces": traces,
+        })
+        # Fit metrics: compare each model to the first (reference)
+        _idx0, _lbl0, ref_df = datasets[0]
+        _rb, ref_share, _rs = normalise_shares(ref_df)
+        for _idx_m, mod_label, mod_df in datasets[1:]:
+            _mb, mod_share, _ms = normalise_shares(mod_df)
+            row_label = (
+                purpose_title if len(datasets) == 2  # noqa: PLR2004
+                else f"{purpose_title} ({mod_label})"
+            )
+            fit_rows.append(compute_fit_row(ref_share, mod_share, row_label))
+
+    # --- Average trip lengths table: pair-toggled ---
+    avg_datasets = pick_datasets(per_label, labels, "nwdc_avg_trip_lengths")
+    has_tables = len(avg_datasets) >= 2 or fit_rows  # noqa: PLR2004
+    if has_tables:
+        parts.append(
+            "<div style='display:flex;gap:24px;flex-wrap:wrap;align-items:start;'>",
+        )
+    if len(avg_datasets) >= 2:  # noqa: PLR2004
+        parts.append("<div><h3>Average Trip Lengths (miles)</h3>")
+        parts.append(render_pairs(avg_datasets, _render_avg_pair))
+        parts.append("</div>")
+    if fit_rows:
+        append_overall_fit(fit_rows)
+        parts.append("<div><h3>Goodness of Fit — Trip Length</h3>")
+        parts.append(fit_table(fit_rows))
+        parts.append("</div>")
+    if has_tables:
+        parts.append("</div>")
+
+    if grid_items:
+        parts.append(_render_grid(grid_items))
+
+    return "\n".join(parts) if parts else "<p>Insufficient data for comparison.</p>"
+
+
+def _render_avg_pair(
+    obs_label: str,
+    obs: pl.DataFrame,
+    mod_label: str,
+    mod: pl.DataFrame,
+) -> str:
+    return _avg_trip_table(obs, mod, obs_label, mod_label)
+
+
+def _render_grid(items: list[dict]) -> str:
+    grid_html = (
+        "<div style='display:grid;grid-template-columns:1fr 1fr;"
+        "gap:8px;margin:12px 0;'>\n"
+    )
+    for item in items:
+        grid_html += (
+            f"  <div class='tlfd-cell'>\n"
+            f"    <div id='{item['div_id']}' "
+            f"style='width:100%;height:320px;'></div>\n"
+            f"  </div>\n"
+        )
+    grid_html += "</div>\n"
+
+    tmpl = load_template("nwdc_grid.js")
+    purposes_json = json.dumps(items)
+    js = tmpl.substitute(purposes=purposes_json)
+    grid_html += f"<script>\n{js}\n</script>"
+    return grid_html
+
+
+def _avg_trip_table(
+    obs: pl.DataFrame, mod: pl.DataFrame,
+    obs_label: str, mod_label: str,
+) -> str:
+    obs_rows = {r["purpose"]: r["avg_trip_length"] for r in obs.to_dicts()}
+    mod_rows = {r["purpose"]: r["avg_trip_length"] for r in mod.to_dicts()}
+    all_purposes = list(dict.fromkeys(list(obs_rows) + list(mod_rows)))
+
+    header = (
+        "<table class='cal-table'><thead><tr>"
+        f"<th>Purpose</th><th>{esc(obs_label)}</th>"
+        f"<th>{esc(mod_label)}</th><th>% Change</th>"
+        "</tr></thead><tbody>"
+    )
+    body = ""
+    for p in all_purposes:
+        o = obs_rows.get(p)
+        m = mod_rows.get(p)
+        o_str = f"{o:.2f}" if o is not None else "—"
+        m_str = f"{m:.2f}" if m is not None else "—"
+        if o is not None and m is not None:
+            d_cell = pct_change_cell(o, m)
+        else:
+            d_cell = "<td>—</td>"
+        body += f"<tr><td>{esc(p)}</td><td>{o_str}</td><td>{m_str}</td>{d_cell}</tr>"
+
+    return header + body + "</tbody></table>"

--- a/src/tm1/steps/summaries/calibration/report/templates/ao_chart.js
+++ b/src/tm1/steps/summaries/calibration/report/templates/ao_chart.js
@@ -1,0 +1,8 @@
+Plotly.newPlot('$div_id', [$traces], {
+  barmode: 'stack',
+  title: 'Auto Ownership Distribution by County',
+  xaxis: {tickformat: '.0%', title: 'Share', range: [0, 1]},
+  yaxis: {automargin: true},
+  legend: {orientation: 'h', y: -0.08, x: 0.5, xanchor: 'center', traceorder: 'normal'},
+  margin: {l: 220, b: 60}
+}, {responsive: true});

--- a/src/tm1/steps/summaries/calibration/report/templates/cdap_chart.js
+++ b/src/tm1/steps/summaries/calibration/report/templates/cdap_chart.js
@@ -1,0 +1,8 @@
+Plotly.newPlot('$div_id', [$traces], {
+  barmode: 'group',
+  title: 'Activity Pattern Shares by Person Type',
+  yaxis: {tickformat: '.0%'},
+  legend: {orientation: 'h', y: -0.25, x: 0.5, xanchor: 'center'},
+  margin: {l: 60, r: 30, t: 40, b: 80},
+  width: 900
+});

--- a/src/tm1/steps/summaries/calibration/report/templates/nwdc_grid.js
+++ b/src/tm1/steps/summaries/calibration/report/templates/nwdc_grid.js
@@ -1,0 +1,26 @@
+(function() {
+  var purposes = $purposes;
+  var btnCss = 'margin:4px 0;padding:3px 8px;font-size:11px;cursor:pointer;';
+  purposes.forEach(function(p) {
+    Plotly.newPlot(p.div_id, p.traces, {
+      title: {text: p.title, font: {size: 13}},
+      xaxis: {title: 'Distance (miles)', rangemode: 'nonnegative', range: [0, 30]},
+      yaxis: {tickformat: '.1%'},
+      legend: {orientation: 'h', y: -0.25, x: 0.5, xanchor: 'center'},
+      margin: {t: 35, b: 60, l: 45, r: 10}
+    }, {responsive: true});
+
+    var div = document.getElementById(p.div_id);
+    var btn = document.createElement('button');
+    btn.textContent = 'Log Scale';
+    btn.style.cssText = btnCss;
+    btn.onclick = function() {
+      var cur = div.layout.yaxis.type;
+      var newType = (cur === 'log') ? 'linear' : 'log';
+      var fmt = (newType === 'log') ? '.1e' : '.1%';
+      Plotly.relayout(div, {'yaxis.type': newType, 'yaxis.tickformat': fmt});
+      btn.textContent = (newType === 'log') ? 'Linear Scale' : 'Log Scale';
+    };
+    div.after(btn);
+  });
+})();

--- a/src/tm1/steps/summaries/calibration/report/templates/page.html
+++ b/src/tm1/steps/summaries/calibration/report/templates/page.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Calibration Report</title>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+       margin: 20px; background: #fafafa; color: #333; }
+h2 { margin-bottom: 4px; }
+.timestamp { color: #888; font-size: 0.85em; margin-bottom: 16px; }
+
+/* --- Global dataset toggle --- */
+.ds-bar { display: flex; gap: 6px; margin: 0 0 16px; }
+.ds-btn { padding: 6px 14px; border: 1px solid #bbb; background: #f0f0f0; cursor: pointer;
+          font-size: 0.85em; border-radius: 4px; transition: background 0.15s; }
+.ds-btn.active { background: #4e79a7; color: #fff; border-color: #4e79a7; font-weight: 600; }
+
+/* --- Tab navigation --- */
+.tab-bar { display: flex; gap: 4px; margin-bottom: 16px; border-bottom: 2px solid #ddd; }
+.tab-btn { padding: 8px 20px; border: none; background: #eee; cursor: pointer;
+            font-size: 0.95em; border-radius: 4px 4px 0 0; }
+.tab-btn.active { background: #fff; border-bottom: 2px solid #4e79a7; font-weight: 600; }
+.tab-pane { background: #fff; padding: 20px; border-radius: 0 4px 4px 4px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+
+/* --- Tables --- */
+.cal-table { border-collapse: collapse; font-size: 0.85em; margin: 12px 0 8px; }
+.cal-table th, .cal-table td { border: 1px solid #ccc; padding: 4px 8px; text-align: right;
+                              overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cal-table th { background: #f0f0f0; position: sticky; top: 0; }
+.cal-table td:first-child, .cal-table th:first-child { text-align: left; font-weight: 500; }
+.cal-table .group-sep { border-left: 2px solid #999; }
+.fit-table { border-collapse: collapse; font-size: 0.85em; margin: 12px 0 8px; }
+.fit-table th, .fit-table td { border: 1px solid #ccc; padding: 4px 10px; }
+.fit-table th { background: #f0f0f0; text-align: left; }
+.fit-table td { text-align: right; }
+.fit-table td:first-child { text-align: left; font-weight: 500; }
+
+/* --- Delta highlighting --- */
+td.err-warn, .err-warn { background: #fff3cd !important; }
+td.err-bad, .err-bad   { background: #f8d7da !important; }
+
+/* --- Notes --- */
+.delta-note { font-size: 0.8em; color: #666; margin: 2px 0 16px; }
+
+h3 { margin-top: 28px; }
+h4 { margin-top: 20px; color: #555; }
+</style>
+</head>
+<body>
+<h2>Calibration Report</h2>
+<div class="timestamp">Generated $timestamp</div>
+$notes_banner
+$dataset_bar
+<div class="tab-bar">
+$tab_buttons
+</div>
+$tab_panes
+<script>
+/* --- Tab switching --- */
+function showTab(id) {
+  document.querySelectorAll('.tab-pane').forEach(function(p) { p.style.display = 'none'; });
+  document.querySelectorAll('.tab-btn').forEach(function(b) { b.classList.remove('active'); });
+  document.getElementById(id).style.display = 'block';
+  event.target.classList.add('active');
+  // Resize any Plotly charts that were hidden
+  var pane = document.getElementById(id);
+  pane.querySelectorAll('.js-plotly-plot').forEach(function(el) { Plotly.Plots.resize(el); });
+}
+
+/* --- Global dataset pair toggle ---
+   Buttons have data-idx. Exactly 2 are active at a time.
+   Clicking an inactive button replaces the oldest active one (FIFO).
+   All .pair-section elements show/hide based on their data-pair attribute. */
+var activePair = [$default_pair];
+
+function toggleDS(idx) {
+  if (activePair.indexOf(idx) !== -1) return;
+  activePair.shift();
+  activePair.push(idx);
+  // Update buttons
+  document.querySelectorAll('.ds-btn').forEach(function(b) {
+    b.classList.toggle('active', activePair.indexOf(parseInt(b.dataset.idx)) !== -1);
+  });
+  // Show/hide pair sections globally
+  var key = Math.min(activePair[0], activePair[1]) + '_' + Math.max(activePair[0], activePair[1]);
+  document.querySelectorAll('.pair-section').forEach(function(el) {
+    el.style.display = el.dataset.pair === key ? '' : 'none';
+  });
+  // Resize visible charts
+  document.querySelectorAll('.pair-section[data-pair="' + key + '"] .js-plotly-plot').forEach(function(el) {
+    Plotly.Plots.resize(el);
+  });
+}
+</script>
+</body>
+</html>

--- a/src/tm1/steps/summaries/calibration/report/templates/tlfd_chart.js
+++ b/src/tm1/steps/summaries/calibration/report/templates/tlfd_chart.js
@@ -1,0 +1,22 @@
+(function() {
+  var traces = $traces_json;
+  Plotly.newPlot('$div_id', traces, {
+    title: 'TLFD — $trip_title',
+    xaxis: {title: 'Distance (miles)', rangemode: 'nonnegative'},
+    yaxis: {title: 'Share', tickformat: '.1%'},
+    legend: {orientation: 'h', y: -0.2, x: 0.5, xanchor: 'center'},
+    margin: {b: 60}
+  });
+  var div = document.getElementById('$div_id');
+  var btn = document.createElement('button');
+  btn.textContent = 'Log Scale';
+  btn.style.cssText = 'margin:4px 0;padding:3px 8px;font-size:11px;cursor:pointer;';
+  btn.onclick = function() {
+    var cur = div.layout.yaxis.type;
+    var newType = (cur === 'log') ? 'linear' : 'log';
+    var fmt = (newType === 'log') ? '.1e' : '.1%';
+    Plotly.relayout(div, {'yaxis.type': newType, 'yaxis.tickformat': fmt});
+    btn.textContent = (newType === 'log') ? 'Linear Scale' : 'Log Scale';
+  };
+  div.parentNode.insertBefore(btn, div.nextSibling);
+})();

--- a/src/tm1/steps/summaries/calibration/report/tour_mode.py
+++ b/src/tm1/steps/summaries/calibration/report/tour_mode.py
@@ -1,0 +1,205 @@
+"""Tour Mode Choice tab renderer."""
+
+import polars as pl
+
+from .helpers import (
+    MODE_COLOURS,
+    MODE_GROUPS,
+    append_overall_fit,
+    compute_fit_row,
+    esc,
+    esc_js,
+    fit_table,
+    mode_parity_table,
+    pick_datasets,
+    pp_delta_cell,
+    render_pairs,
+    wrap_chart,
+)
+
+
+def render(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+) -> str:
+    datasets = pick_datasets(per_label, labels, "tour_mode_summary")
+    if len(datasets) < 2:  # noqa: PLR2004
+        return "<p>Insufficient data for comparison.</p>"
+    return render_pairs(datasets, _render_pair)
+
+
+def _render_pair(
+    obs_label: str,
+    obs: pl.DataFrame,
+    mod_label: str,
+    mod: pl.DataFrame,
+) -> str:
+    chart_id = f"tmc_{obs_label}_{mod_label}".replace(" ", "_")
+    parts: list[str] = [
+        "<h3>Tour Mode Shares by Purpose</h3>",
+        _mode_share_table(obs, mod, obs_label, mod_label),
+        "<h3>Mode Parity (all 21 modes, all purposes)</h3>",
+        mode_parity_table(obs, mod, obs_label, mod_label, "tour_mode", "num_tours"),
+        "<h3>Goodness of Fit</h3>",
+        _fit_section(obs, mod),
+        "<h3>Mode Share Chart</h3>",
+        _mode_chart(obs, mod, obs_label, mod_label, chart_id),
+    ]
+    return "\n".join(parts)
+
+
+def _group_modes(df: pl.DataFrame) -> pl.DataFrame:
+    mode_map: dict[int, str] = {}
+    for group_name, modes in MODE_GROUPS.items():
+        for m in modes:
+            mode_map[m] = group_name
+    return (
+        df.with_columns(
+            pl.col("tour_mode")
+            .replace_strict(mode_map, default="Other")
+            .alias("mode_group"),
+        )
+        .group_by("simple_purpose", "mode_group")
+        .agg(pl.col("num_tours").sum())
+        .sort("simple_purpose", "mode_group")
+    )
+
+
+def _compute_shares(df: pl.DataFrame) -> tuple[pl.DataFrame, dict]:
+    g = _group_modes(df)
+    totals = g.group_by("simple_purpose").agg(pl.col("num_tours").sum().alias("total"))
+    g = g.join(totals, on="simple_purpose").with_columns(
+        (pl.col("num_tours") / pl.col("total")).alias("share"),
+    )
+    lookup = {
+        (r["simple_purpose"], r["mode_group"]): r["share"]
+        for r in g.to_dicts()
+    }
+    return g, lookup
+
+
+def _mode_share_table(obs: pl.DataFrame, mod: pl.DataFrame, obs_label: str, mod_label: str) -> str:
+    _obs_g, obs_lookup = _compute_shares(obs)
+    _mod_g, mod_lookup = _compute_shares(mod)
+
+    purposes = sorted(
+        set(k[0] for k in obs_lookup) & set(k[0] for k in mod_lookup),
+    )
+    mode_groups = list(MODE_GROUPS)
+
+    header = (
+        "<table class='cal-table'><thead><tr>"
+        "<th>Purpose</th><th>Mode</th>"
+        f"<th>{esc(obs_label)}</th><th>{esc(mod_label)}</th><th>Delta (pp)</th>"
+        "</tr></thead><tbody>"
+    )
+    body = ""
+    for p in purposes:
+        first = True
+        for mg in mode_groups:
+            o = obs_lookup.get((p, mg), 0.0)
+            m = mod_lookup.get((p, mg), 0.0)
+            p_cell = f"<td rowspan='{len(mode_groups)}'>{esc(p)}</td>" if first else ""
+            body += (
+                f"<tr>{p_cell}<td>{esc(mg)}</td>"
+                f"<td>{o:.1%}</td><td>{m:.1%}</td>"
+                f"{pp_delta_cell(o, m)}</tr>"
+            )
+            first = False
+
+    return header + body + "</tbody></table>"
+
+
+def _fit_section(obs: pl.DataFrame, mod: pl.DataFrame) -> str:
+    _obs_g, obs_lookup = _compute_shares(obs)
+    _mod_g, mod_lookup = _compute_shares(mod)
+
+    purposes = sorted(
+        set(k[0] for k in obs_lookup) & set(k[0] for k in mod_lookup),
+    )
+    mode_groups = list(MODE_GROUPS)
+
+    fit_rows: list[dict] = []
+    for p in purposes:
+        obs_shares = [obs_lookup.get((p, mg), 0.0) for mg in mode_groups]
+        mod_shares = [mod_lookup.get((p, mg), 0.0) for mg in mode_groups]
+        fit_rows.append(compute_fit_row(obs_shares, mod_shares, p))
+
+    append_overall_fit(fit_rows)
+    return fit_table(fit_rows)
+
+
+def _mode_chart(
+    obs: pl.DataFrame, mod: pl.DataFrame,
+    obs_label: str, mod_label: str, chart_id: str,
+) -> str:
+    obs_g = _group_modes(obs)
+    mod_g = _group_modes(mod)
+
+    purposes = sorted(
+        set(obs_g["simple_purpose"].unique().to_list())
+        & set(mod_g["simple_purpose"].unique().to_list()),
+    )
+    mode_groups = list(MODE_GROUPS)
+
+    obs_totals = {
+        r["simple_purpose"]: r["total"]
+        for r in obs_g.group_by("simple_purpose")
+        .agg(pl.col("num_tours").sum().alias("total"))
+        .to_dicts()
+    }
+    mod_totals = {
+        r["simple_purpose"]: r["total"]
+        for r in mod_g.group_by("simple_purpose")
+        .agg(pl.col("num_tours").sum().alias("total"))
+        .to_dicts()
+    }
+    obs_lookup = {
+        (r["simple_purpose"], r["mode_group"]): r["num_tours"]
+        for r in obs_g.to_dicts()
+    }
+    mod_lookup = {
+        (r["simple_purpose"], r["mode_group"]): r["num_tours"]
+        for r in mod_g.to_dicts()
+    }
+
+    y_labels: list[str] = []
+    spacer_idx = 0
+    for p in reversed(purposes):
+        if y_labels:
+            spacer_idx += 1
+            y_labels.append(" " * spacer_idx)
+        y_labels.append(f"{p} ({mod_label})")
+        y_labels.append(f"{p} ({obs_label})")
+
+    traces: list[str] = []
+    for i, mg in enumerate(mode_groups):
+        colour = MODE_COLOURS[i % len(MODE_COLOURS)]
+        x_vals: list[float] = []
+        first = True
+        for p in reversed(purposes):
+            if not first:
+                x_vals.append(0)
+            first = False
+            mod_share = mod_lookup.get((p, mg), 0) / (mod_totals.get(p) or 1)
+            obs_share = obs_lookup.get((p, mg), 0) / (obs_totals.get(p) or 1)
+            x_vals.append(mod_share)
+            x_vals.append(obs_share)
+        traces.append(
+            f"{{name:'{esc_js(mg)}', "
+            f"y:{y_labels!r}, x:{x_vals!r}, type:'bar', orientation:'h', "
+            f"marker:{{color:'{colour}'}}}}",
+        )
+
+    height = max(400, len(purposes) * 100)
+    js = (
+        f"Plotly.newPlot('{chart_id}', [{', '.join(traces)}], {{"
+        f"barmode:'stack', "
+        f"title:'Tour Mode Shares by Purpose', "
+        f"xaxis:{{tickformat:'.0%', title:'Share', range:[0,1]}}, "
+        f"yaxis:{{automargin:true}}, "
+        f"legend:{{orientation:'h', y:-0.12, x:0.5, xanchor:'center'}}, "
+        f"margin:{{l:180, t:40, b:60}}"
+        f"}});"
+    )
+    return wrap_chart(chart_id, js, width=1000, height=height)

--- a/src/tm1/steps/summaries/calibration/report/trip_mode.py
+++ b/src/tm1/steps/summaries/calibration/report/trip_mode.py
@@ -1,0 +1,206 @@
+"""Trip Mode Choice tab renderer."""
+
+import polars as pl
+
+from .helpers import (
+    MODE_COLOURS,
+    MODE_GROUPS,
+    append_overall_fit,
+    compute_fit_row,
+    esc,
+    esc_js,
+    fit_table,
+    mode_parity_table,
+    pick_datasets,
+    pp_delta_cell,
+    render_pairs,
+    wrap_chart,
+)
+
+
+def render(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+) -> str:
+    datasets = pick_datasets(per_label, labels, "trip_mode_summary")
+    if len(datasets) < 2:  # noqa: PLR2004
+        return "<p>Insufficient data for comparison.</p>"
+    return render_pairs(datasets, _render_pair)
+
+
+def _render_pair(
+    obs_label: str,
+    obs: pl.DataFrame,
+    mod_label: str,
+    mod: pl.DataFrame,
+) -> str:
+    chart_id = f"trmc_{obs_label}_{mod_label}".replace(" ", "_")
+    parts: list[str] = [
+        "<h3>Trip Mode Shares by Purpose</h3>",
+        _mode_share_table(obs, mod, obs_label, mod_label),
+        "<h3>Mode Parity (all 21 modes, all purposes)</h3>",
+        mode_parity_table(obs, mod, obs_label, mod_label, "trip_mode", "num_trips"),
+        "<h3>Goodness of Fit</h3>",
+        _fit_section(obs, mod),
+        "<h3>Mode Share Chart</h3>",
+        _mode_chart(obs, mod, obs_label, mod_label, chart_id),
+    ]
+    return "\n".join(parts)
+
+
+def _group_modes(df: pl.DataFrame) -> pl.DataFrame:
+    mode_map: dict[int, str] = {}
+    for group_name, modes in MODE_GROUPS.items():
+        for m in modes:
+            mode_map[m] = group_name
+    return (
+        df.with_columns(
+            pl.col("trip_mode")
+            .replace_strict(mode_map, default="Other")
+            .alias("mode_group"),
+        )
+        .group_by("simple_purpose", "mode_group")
+        .agg(pl.col("num_trips").sum())
+        .sort("simple_purpose", "mode_group")
+    )
+
+
+def _compute_shares(df: pl.DataFrame) -> tuple[pl.DataFrame, dict]:
+    """Group modes, compute shares, return (df, lookup dict)."""
+    g = _group_modes(df)
+    totals = g.group_by("simple_purpose").agg(pl.col("num_trips").sum().alias("total"))
+    g = g.join(totals, on="simple_purpose").with_columns(
+        (pl.col("num_trips") / pl.col("total")).alias("share"),
+    )
+    lookup = {
+        (r["simple_purpose"], r["mode_group"]): r["share"]
+        for r in g.to_dicts()
+    }
+    return g, lookup
+
+
+def _mode_share_table(obs: pl.DataFrame, mod: pl.DataFrame, obs_label: str, mod_label: str) -> str:
+    _obs_g, obs_lookup = _compute_shares(obs)
+    mod_g, mod_lookup = _compute_shares(mod)
+
+    purposes = sorted(
+        set(k[0] for k in obs_lookup) & set(k[0] for k in mod_lookup),
+    )
+    mode_groups = list(MODE_GROUPS)
+
+    header = (
+        "<table class='cal-table'><thead><tr>"
+        "<th>Purpose</th><th>Mode</th>"
+        f"<th>{esc(obs_label)}</th><th>{esc(mod_label)}</th><th>Delta (pp)</th>"
+        "</tr></thead><tbody>"
+    )
+    body = ""
+    for p in purposes:
+        first = True
+        for mg in mode_groups:
+            o = obs_lookup.get((p, mg), 0.0)
+            m = mod_lookup.get((p, mg), 0.0)
+            p_cell = f"<td rowspan='{len(mode_groups)}'>{esc(p)}</td>" if first else ""
+            body += (
+                f"<tr>{p_cell}<td>{esc(mg)}</td>"
+                f"<td>{o:.1%}</td><td>{m:.1%}</td>"
+                f"{pp_delta_cell(o, m)}</tr>"
+            )
+            first = False
+
+    return header + body + "</tbody></table>"
+
+
+def _fit_section(obs: pl.DataFrame, mod: pl.DataFrame) -> str:
+    _obs_g, obs_lookup = _compute_shares(obs)
+    _mod_g, mod_lookup = _compute_shares(mod)
+
+    purposes = sorted(
+        set(k[0] for k in obs_lookup) & set(k[0] for k in mod_lookup),
+    )
+    mode_groups = list(MODE_GROUPS)
+
+    fit_rows: list[dict] = []
+    for p in purposes:
+        obs_shares = [obs_lookup.get((p, mg), 0.0) for mg in mode_groups]
+        mod_shares = [mod_lookup.get((p, mg), 0.0) for mg in mode_groups]
+        fit_rows.append(compute_fit_row(obs_shares, mod_shares, p))
+
+    append_overall_fit(fit_rows)
+    return fit_table(fit_rows)
+
+
+def _mode_chart(
+    obs: pl.DataFrame, mod: pl.DataFrame,
+    obs_label: str, mod_label: str, chart_id: str,
+) -> str:
+    obs_g = _group_modes(obs)
+    mod_g = _group_modes(mod)
+
+    purposes = sorted(
+        set(obs_g["simple_purpose"].unique().to_list())
+        & set(mod_g["simple_purpose"].unique().to_list()),
+    )
+    mode_groups = list(MODE_GROUPS)
+
+    obs_totals = {
+        r["simple_purpose"]: r["total"]
+        for r in obs_g.group_by("simple_purpose")
+        .agg(pl.col("num_trips").sum().alias("total"))
+        .to_dicts()
+    }
+    mod_totals = {
+        r["simple_purpose"]: r["total"]
+        for r in mod_g.group_by("simple_purpose")
+        .agg(pl.col("num_trips").sum().alias("total"))
+        .to_dicts()
+    }
+    obs_lookup = {
+        (r["simple_purpose"], r["mode_group"]): r["num_trips"]
+        for r in obs_g.to_dicts()
+    }
+    mod_lookup = {
+        (r["simple_purpose"], r["mode_group"]): r["num_trips"]
+        for r in mod_g.to_dicts()
+    }
+
+    y_labels: list[str] = []
+    spacer_idx = 0
+    for p in reversed(purposes):
+        if y_labels:
+            spacer_idx += 1
+            y_labels.append(" " * spacer_idx)
+        y_labels.append(f"{p} ({mod_label})")
+        y_labels.append(f"{p} ({obs_label})")
+
+    traces: list[str] = []
+    for i, mg in enumerate(mode_groups):
+        colour = MODE_COLOURS[i % len(MODE_COLOURS)]
+        x_vals: list[float] = []
+        first = True
+        for p in reversed(purposes):
+            if not first:
+                x_vals.append(0)
+            first = False
+            mod_share = mod_lookup.get((p, mg), 0) / (mod_totals.get(p) or 1)
+            obs_share = obs_lookup.get((p, mg), 0) / (obs_totals.get(p) or 1)
+            x_vals.append(mod_share)
+            x_vals.append(obs_share)
+        traces.append(
+            f"{{name:'{esc_js(mg)}', "
+            f"y:{y_labels!r}, x:{x_vals!r}, type:'bar', orientation:'h', "
+            f"marker:{{color:'{colour}'}}}}",
+        )
+
+    height = max(400, len(purposes) * 100)
+    js = (
+        f"Plotly.newPlot('{chart_id}', [{', '.join(traces)}], {{"
+        f"barmode:'stack', "
+        f"title:'Trip Mode Shares by Purpose', "
+        f"xaxis:{{tickformat:'.0%', title:'Share', range:[0,1]}}, "
+        f"yaxis:{{automargin:true}}, "
+        f"legend:{{orientation:'h', y:-0.12, x:0.5, xanchor:'center'}}, "
+        f"margin:{{l:180, t:40, b:60}}"
+        f"}});"
+    )
+    return wrap_chart(chart_id, js, width=1000, height=height)

--- a/src/tm1/steps/summaries/calibration/report/wfh.py
+++ b/src/tm1/steps/summaries/calibration/report/wfh.py
@@ -1,0 +1,151 @@
+"""Work from Home tab renderer."""
+
+import polars as pl
+
+from .helpers import (
+    DATASET_COLOURS,
+    esc,
+    pick_datasets,
+    pp_delta_cell,
+    render_pairs,
+    wrap_chart,
+)
+
+
+def render(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+) -> str:
+    datasets = pick_datasets(per_label, labels, "county_summary")
+    if len(datasets) < 2:  # noqa: PLR2004
+        return "<p>Need at least two datasets for WFH comparison.</p>"
+
+    chart_html = _nway_chart(datasets)
+    tables_html = render_pairs(datasets, _render_pair)
+    overall_html = _overall_table(per_label, labels)
+
+    return (
+        f"{overall_html}"
+        "<div style='display:grid;grid-template-columns:max-content 1fr;"
+        "gap:1rem;align-items:start;margin-top:1rem;'>"
+        f"<div>{tables_html}</div>"
+        f"<div>{chart_html}</div>"
+        "</div>"
+    )
+
+
+def _render_pair(
+    obs_label: str,
+    obs: pl.DataFrame,
+    mod_label: str,
+    mod: pl.DataFrame,
+) -> str:
+    obs_rows = obs.sort("county_name").to_dicts()
+    mod_by_county: dict[str, dict] = {
+        r["county_name"]: r for r in mod.sort("county_name").to_dicts()
+    }
+
+    header = (
+        "<table class='cal-table' style='width:auto;table-layout:auto;'>"
+        "<thead><tr>"
+        "<th>County</th>"
+        f"<th>{esc(obs_label)} Rate</th>"
+        f"<th>{esc(mod_label)} Rate</th>"
+        "<th>Delta (pp)</th>"
+        "</tr></thead><tbody>"
+    )
+    body = ""
+    for row in obs_rows:
+        county = row["county_name"]
+        mr = mod_by_county.get(county, {})
+        o_rate = row.get("wfh_rate", 0) or 0
+        m_rate = mr.get("wfh_rate", 0) or 0
+        body += (
+            f"<tr><td>{esc(str(county))}</td>"
+            f"<td>{o_rate:.1%}</td><td>{m_rate:.1%}</td>"
+            f"{pp_delta_cell(o_rate, m_rate)}</tr>"
+        )
+
+    # Total row
+    o_total = sum(r.get("wfh", 0) or 0 for r in obs_rows)
+    o_workers = sum(r.get("workers", 0) or 0 for r in obs_rows)
+    m_total = sum(r.get("wfh", 0) or 0 for r in mod_by_county.values())
+    m_workers = sum(r.get("workers", 0) or 0 for r in mod_by_county.values())
+    o_rate = o_total / o_workers if o_workers else 0
+    m_rate = m_total / m_workers if m_workers else 0
+    body += (
+        f"<tr style='font-weight:bold'><td>Total</td>"
+        f"<td>{o_rate:.1%}</td><td>{m_rate:.1%}</td>"
+        f"{pp_delta_cell(o_rate, m_rate)}</tr>"
+    )
+
+    return "<h3>WFH Rate by County</h3>" + header + body + "</tbody></table>"
+
+
+def _overall_table(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+) -> str:
+    """Render a compact overall summary (FT/PT/Total) across all datasets."""
+    datasets = [
+        (label, per_label[label]["overall_summary"])
+        for label in labels
+        if "overall_summary" in per_label.get(label, {})
+    ]
+    if not datasets:
+        return ""
+
+    header = "<table class='cal-table' style='width:auto;margin-bottom:1rem;'><thead><tr><th>Category</th>"
+    for label, _ in datasets:
+        header += f"<th>{esc(label)} WFH Rate</th>"
+    header += "</tr></thead><tbody>"
+
+    # Collect all categories
+    all_cats: list[str] = []
+    for _, df in datasets:
+        for c in df["category"].to_list():
+            if c not in all_cats:
+                all_cats.append(c)
+
+    body = ""
+    for cat in all_cats:
+        body += f"<tr><td>{esc(cat)}</td>"
+        for _, df in datasets:
+            row = df.filter(pl.col("category") == cat)
+            if row.height > 0:
+                rate = row["wfh_rate"][0]
+                body += f"<td>{rate:.1%}</td>"
+            else:
+                body += "<td>—</td>"
+        body += "</tr>"
+
+    return "<h3>WFH Rate Overview</h3>" + header + body + "</tbody></table>"
+
+
+def _nway_chart(datasets: list[tuple[int, str, pl.DataFrame]]) -> str:
+    """Grouped bar chart of WFH rate by county, one bar per dataset."""
+    counties = datasets[0][2].sort("county_name")["county_name"].to_list()
+
+    traces = []
+    for i, (gi, label, df) in enumerate(datasets):
+        rates = []
+        by_county = {r["county_name"]: r for r in df.to_dicts()}
+        for c in counties:
+            r = by_county.get(c, {})
+            rates.append(round((r.get("wfh_rate", 0) or 0) * 100, 1))
+        colour = DATASET_COLOURS[gi % len(DATASET_COLOURS)]
+        traces.append(
+            f"{{x: {counties!r}, y: {rates}, name: '{label}', "
+            f"type: 'bar', marker: {{color: '{colour}'}}}}"
+        )
+
+    div_id = "wfh_county_chart"
+    data_js = ",\n".join(traces)
+    js = (
+        f"Plotly.newPlot('{div_id}', [{data_js}], "
+        f"{{barmode:'group', title:'WFH Rate by County',"
+        f" yaxis:{{title:'WFH Rate (%)', rangemode:'tozero'}},"
+        f" legend:{{orientation:'h', y:-0.25, x:0.5, xanchor:'center'}},"
+        f" margin:{{t:40,b:80}}}}, {{responsive:true}});"
+    )
+    return wrap_chart(div_id, js, height=350)

--- a/src/tm1/steps/summaries/calibration/report/wsloc.py
+++ b/src/tm1/steps/summaries/calibration/report/wsloc.py
@@ -1,0 +1,413 @@
+"""Work / School Location tab renderer."""
+
+import json
+import logging
+from collections.abc import Sequence
+
+import polars as pl
+
+from .helpers import (
+    DATASET_COLOURS,
+    append_overall_fit,
+    compute_fit_row,
+    esc,
+    fit_table,
+    normalise_shares,
+    pct_change_cell,
+    pick_datasets,
+    render_pairs,
+    tlfd_traces_nway,
+    wrap_chart,
+)
+
+log = logging.getLogger(__name__)
+
+
+def render(
+    per_label: dict[str, dict[str, pl.DataFrame]],
+    labels: list[str],
+    *,
+    survey_labels: set[str] | None = None,
+) -> str:
+    parts: list[str] = []
+
+    # Average trip lengths table — pair-toggled
+    avg_datasets = pick_datasets(per_label, labels, "avg_trip_lengths")
+    if len(avg_datasets) >= 2:  # noqa: PLR2004
+        parts.append("<h3>Average Trip Lengths (miles)</h3>")
+        parts.append(render_pairs(avg_datasets, _render_avg_pair))
+
+    # WFH-split work distance parity — both engines keep a usual-workplace TAZ
+    # for WFH workers, so a faithful WFH model reproduces the higher WFH-worker
+    # distance. Regional work distance washes out (~+0.6%); per-county residual
+    # is destination-allocation, not a WFH defect.
+    # _wfh_split_work() returns None when a dataset carries no work_from_home
+    # column. In a FULL run every dataset has one (BATS + CTRAMP via wfh_choice,
+    # ActivitySim via the work_from_home model), so this only bites on a PARTIAL
+    # run that stops before work_from_home executes -- e.g. a location-models-only
+    # or early-ablation run. Drop those before deciding a comparison is possible.
+    wfh_datasets = _usable_wfh_datasets(
+        pick_datasets(per_label, labels, "wfh_split_work"),
+    )
+    if len(wfh_datasets) >= 2:  # noqa: PLR2004
+        parts.append("<h3>Work Distance by WFH Status (miles)</h3>")
+        parts.append(_wfh_split_table(wfh_datasets))
+        parts.append(
+            "<p class='note'>* Both models assign a usual-workplace TAZ to "
+            "work-from-home workers (WFH is an overlay, not an exclusion — "
+            "verified 100% of CTRAMP wfh=1 keep a WorkLocation). WFH workers "
+            "commute farther on average, and ActivitySim reproduces that split; "
+            "a close match here isolates any per-county gap to destination "
+            "allocation rather than the WFH model.</p>"
+        )
+
+    # Fit metrics across all datasets
+    fit_rows: list[dict] = []
+    trip_purposes = [
+        ("trip_tlfd_work", "Work"),
+        ("trip_tlfd_univ", "University"),
+        ("trip_tlfd_school", "School"),
+    ]
+    for trip_key, trip_title in trip_purposes:
+        ds = pick_datasets(per_label, labels, trip_key)
+        if len(ds) < 2:  # noqa: PLR2004
+            continue
+        _idx0, _lbl0, ref_df = ds[0]
+        _rb, ref_share, _rs = normalise_shares(ref_df)
+        for _idx_m, mod_label, mod_df in ds[1:]:
+            _mb, mod_share, _ms = normalise_shares(mod_df)
+            row_label = (
+                trip_title if len(ds) == 2  # noqa: PLR2004
+                else f"{trip_title} ({mod_label})"
+            )
+            fit_rows.append(compute_fit_row(ref_share, mod_share, row_label))
+
+    if fit_rows:
+        append_overall_fit(fit_rows)
+        parts.append("<h3>Goodness of Fit — Trip Length</h3>")
+        parts.append(fit_table(fit_rows))
+
+    # TLFD plots — all datasets overlaid, in a compact grid
+    tlfd_items: list[tuple[str, str, list]] = []
+    for trip_key, trip_title in trip_purposes:
+        ds = pick_datasets(per_label, labels, trip_key)
+        if len(ds) < 2:  # noqa: PLR2004
+            continue
+        tlfd_items.append((trip_key, trip_title, ds))
+
+    if tlfd_items:
+        parts.append("<h3>Trip Length Frequency Distribution</h3>")
+        parts.append(
+            "<button id='tlfd_log_toggle' style='margin:4px 0;padding:3px 8px;"
+            "font-size:11px;cursor:pointer;' onclick=\""
+            "var ids=[" + ",".join(
+                f"'tlfd_{k}'" for k, _, _ in tlfd_items
+            ) + "];"
+            "var btn=this;var cur=(btn.textContent==='Log Scale')?'log':'linear';"
+            "var fmt=(cur==='log')?'.1e':'.1%';"
+            "ids.forEach(function(id){Plotly.relayout(id,{'yaxis.type':cur,'yaxis.tickformat':fmt});});"
+            "btn.textContent=(cur==='log')?'Linear Scale':'Log Scale';"
+            "\">Log Scale</button>"
+        )
+        parts.append(_tlfd_grid(tlfd_items, survey_labels=survey_labels))
+        parts.append(
+            "<p class='note'>* School comparisons exclude preschool-age "
+            "children (ActivitySim ptype 8). ActivitySim assigns school "
+            "locations to these children, but CTRAMP labels them "
+            "&ldquo;Not student&rdquo; so they are omitted for "
+            "apples-to-apples comparison.</p>"
+        )
+        parts.append(
+            "<p class='note'>* School/university zone assignment variance "
+            "is magnified by small sample rates. At 15% sampling, ~62% of "
+            "persons receive different zone draws between models due to "
+            "Monte Carlo randomness. This variance will shrink "
+            "substantially with larger sample rates.</p>"
+        )
+
+    # Per-county violin + CDF plots
+    dist_keys = [
+        ("dist_samples_work", "Work"),
+        ("dist_samples_school", "School"),
+    ]
+    for dist_key, dist_title in dist_keys:
+        ds = pick_datasets(per_label, labels, dist_key)
+        if len(ds) < 2:  # noqa: PLR2004
+            continue
+        parts.append(f"<h3>Distance Distribution by County — {dist_title}</h3>")
+        parts.append(_violin_chart(ds, dist_key))
+        parts.append(f"<h3>Distance CDF by County — {dist_title}</h3>")
+        parts.append(_cdf_grid(ds, dist_key))
+
+    return "\n".join(parts) if parts else "<p>Insufficient data for comparison.</p>"
+
+
+def _render_avg_pair(
+    obs_label: str,
+    obs: pl.DataFrame,
+    mod_label: str,
+    mod: pl.DataFrame,
+) -> str:
+    return _avg_trip_table(obs, mod, obs_label, mod_label)
+
+
+def _usable_wfh_datasets(
+    picked: Sequence[tuple[int, str, pl.DataFrame | None]],
+) -> list[tuple[int, str, pl.DataFrame]]:
+    """Drop datasets with no WFH split, loudly distinguishing broken from expected.
+
+    ``_wfh_split_work()`` returns None when a dataset carries no work_from_home
+    column. Two very different situations produce that:
+
+    * **Mixed** (some datasets have it, some don't) -- never expected in a real
+      comparison, since every dataset supplies WFH in a full run. Logged as an
+      ERROR: the parity table would otherwise silently compare an incomplete set.
+    * **Uniformly absent** -- a partial run (location-models-only, or an ablation
+      stage before work_from_home). Legitimate; logged at INFO.
+    """
+    present = [(i, label, df) for i, label, df in picked if df is not None]
+    missing = [label for _, label, df in picked if df is None]
+    if missing and present:
+        log.error(
+            "!!!!! WFH SPLIT IS BROKEN -- A REAL PROBLEM, NOT A HARMLESS SKIP !!!!! "
+            "dataset(s) %s carry NO work_from_home column while %s DO. Every "
+            "dataset supplies it in a full run (BATS/CTRAMP via wfh_choice, "
+            "ActivitySim via the work_from_home model), so a mixed state means "
+            "something is wrong -- check that work_from_home actually executed and "
+            "that the dataset paths point at a complete run. The WFH table EXCLUDES "
+            "%s and is therefore NOT a like-for-like comparison.",
+            missing, [lbl for _, lbl, _ in present], missing,
+        )
+    elif missing:
+        log.info(
+            "Skipping WFH split: no dataset carries work_from_home (%s) -- expected "
+            "for a location-models-only or early-ablation partial run.",
+            ", ".join(missing),
+        )
+    return present
+
+
+def _wfh_split_table(datasets: list[tuple[int, str, pl.DataFrame]]) -> str:
+    """Render mean work distance by WFH status, one column per dataset.
+
+    A ``%Δ`` column compares the last two datasets (ActivitySim vs CTRAMP in
+    the default config order), which is the migration-validation pair.
+    """
+    categories = ["Regular", "Work-from-home"]
+    # label -> {category: mean_dist}
+    by_label: dict[str, dict[str, float]] = {}
+    for _idx, label, df in datasets:
+        by_label[label] = {
+            r["category"]: r["mean_dist"] for r in df.to_dicts()
+        }
+    labels = [lbl for _i, lbl, _d in datasets]
+    show_diff = len(labels) >= 2  # noqa: PLR2004
+
+    header = "<table class='cal-table'><thead><tr><th>WFH status</th>"
+    for lbl in labels:
+        header += f"<th>{esc(lbl)}</th>"
+    if show_diff:
+        header += f"<th>%&Delta; ({esc(labels[-2])}&rarr;{esc(labels[-1])})</th>"
+    header += "</tr></thead><tbody>"
+
+    body = ""
+    for cat in categories:
+        body += f"<tr><td>{esc(cat)}</td>"
+        for lbl in labels:
+            v = by_label.get(lbl, {}).get(cat)
+            body += f"<td>{v:.2f}</td>" if v is not None else "<td>&mdash;</td>"
+        if show_diff:
+            ref = by_label.get(labels[-1], {}).get(cat, 0) or 0
+            mod = by_label.get(labels[-2], {}).get(cat, 0) or 0
+            body += pct_change_cell(ref, mod)
+        body += "</tr>"
+    return header + body + "</tbody></table>"
+
+
+def _tlfd_grid(
+    items: list[tuple[str, str, list]],
+    *,
+    survey_labels: set[str] | None = None,
+) -> str:
+    """Render TLFD charts in a 2-column grid."""
+    parts = ["<div style='display:grid;grid-template-columns:repeat(2,1fr);gap:8px;max-width:100%;'>"]
+    for trip_key, trip_title, ds in items:
+        _bins, traces = tlfd_traces_nway(ds, survey_labels=survey_labels)
+        div_id = f"tlfd_{trip_key}"
+        layout = {
+            "title": {"text": trip_title, "font": {"size": 13}},
+            "xaxis": {"title": "Distance (mi)"},
+            "yaxis": {"title": "Share", "tickformat": ".1%"},
+            "legend": {"orientation": "h", "y": -0.3, "x": 0.5, "xanchor": "center"},
+            "margin": {"l": 45, "r": 10, "t": 30, "b": 55},
+            "height": 320,
+        }
+        js = f"Plotly.newPlot('{div_id}', {json.dumps(traces)}, {json.dumps(layout)}, {{responsive:true}});"
+        parts.append(
+            f"<div style='min-width:0;overflow:hidden;'>"
+            f"<div id='{div_id}' style='width:100%;height:320px;'></div>"
+            f"<script>{js}</script>"
+            f"</div>"
+        )
+    parts.append("</div>")
+    return "\n".join(parts)
+
+
+def _avg_trip_table(
+    obs: pl.DataFrame, mod: pl.DataFrame,
+    obs_label: str, mod_label: str,
+) -> str:
+    trip_cols = [c for c in obs.columns if c != "county"]
+    obs_rows = obs.sort("county").to_dicts()
+    mod_by_c: dict[str, dict] = {
+        r["county"]: r for r in mod.sort("county").to_dicts()
+    }
+
+    ncols = len(trip_cols)
+    header = "<table class='cal-table'><thead><tr>"
+    header += "<th rowspan='2'>County</th>"
+    header += f"<th colspan='{ncols}'>{esc(obs_label)}</th>"
+    header += f"<th colspan='{ncols}'>{esc(mod_label)}</th>"
+    header += f"<th colspan='{ncols}'>% Change</th>"
+    header += "</tr><tr>"
+    for _ in range(3):
+        for tc in trip_cols:
+            header += f"<th>{esc(tc)}</th>"
+    header += "</tr></thead><tbody>"
+
+    body = ""
+    for row in obs_rows:
+        county = row["county"]
+        mr = mod_by_c.get(county, {})
+        body += f"<tr><td>{esc(str(county))}</td>"
+        for tc in trip_cols:
+            val = row.get(tc)
+            body += f"<td>{val:.1f}</td>" if val is not None else "<td>—</td>"
+        for tc in trip_cols:
+            val = mr.get(tc)
+            body += f"<td>{val:.1f}</td>" if val is not None else "<td>—</td>"
+        for tc in trip_cols:
+            obs_val = row.get(tc, 0) or 0
+            mod_val = mr.get(tc, 0) or 0
+            body += pct_change_cell(obs_val, mod_val)
+        body += "</tr>"
+
+    return header + body + "</tbody></table>"
+
+
+# ---------------------------------------------------------------------------
+# Violin chart (per-county, side-by-side datasets)
+# ---------------------------------------------------------------------------
+
+def _violin_chart(
+    datasets: list[tuple[int, str, pl.DataFrame]],
+    key: str,
+) -> str:
+    """Plotly violin plot: one violin per county, side-by-side per dataset."""
+    traces: list[dict] = []
+    for i, (_idx, label, df) in enumerate(datasets):
+        colour = DATASET_COLOURS[i % len(DATASET_COLOURS)]
+        for county in df["county"].unique().sort().to_list():
+            vals = df.filter(pl.col("county") == county)["dist"].to_list()
+            traces.append({
+                "type": "violin",
+                "y": vals,
+                "x0": county,
+                "name": label,
+                "legendgroup": label,
+                "scalegroup": county,
+                "showlegend": county == df["county"].unique().sort().to_list()[0],
+                "side": "negative" if i == 0 else "positive",
+                "line": {"color": colour},
+                "meanline": {"visible": True},
+                "spanmode": "hard",
+            })
+
+    div_id = f"violin_{key}"
+    layout = {
+        "title": "",
+        "violingap": 0,
+        "violingroupgap": 0.05,
+        "violinmode": "overlay",
+        "yaxis": {"title": "Distance (miles)", "rangemode": "nonnegative"},
+        "xaxis": {"title": "Home County"},
+        "legend": {"orientation": "h", "y": -0.15, "x": 0.5, "xanchor": "center"},
+        "margin": {"b": 80, "t": 40},
+        "updatemenus": [{
+            "type": "buttons",
+            "direction": "left",
+            "x": 0.01,
+            "y": 1.08,
+            "buttons": [
+                {"label": "Linear", "method": "relayout", "args": [{"yaxis.type": "linear"}]},
+                {"label": "Log", "method": "relayout", "args": [{"yaxis.type": "log"}]},
+            ],
+        }],
+    }
+    js = (
+        f"Plotly.newPlot('{div_id}', {json.dumps(traces)}, {json.dumps(layout)});"
+    )
+    return wrap_chart(div_id, js, width="100%", height=500)
+
+
+# ---------------------------------------------------------------------------
+# CDF grid (per-county, overlaid datasets)
+# ---------------------------------------------------------------------------
+
+def _cdf_grid(
+    datasets: list[tuple[int, str, pl.DataFrame]],
+    key: str,
+) -> str:
+    """3-column grid of per-county CDF plots + one 'All' CDF."""
+    # Collect all counties across datasets
+    all_counties: list[str] = []
+    for _idx, _label, df in datasets:
+        all_counties.extend(df["county"].unique().to_list())
+    counties = sorted(set(all_counties))
+
+    items: list[dict] = []
+    for county in [*counties, "All"]:
+        div_id = f"cdf_{key}_{county.replace(' ', '_')}"
+        traces: list[dict] = []
+        for i, (_idx, label, df) in enumerate(datasets):
+            if county == "All":
+                vals = sorted(df["dist"].to_list())
+            else:
+                vals = sorted(
+                    df.filter(pl.col("county") == county)["dist"].to_list()
+                )
+            if not vals:
+                continue
+            n = len(vals)
+            cdf = [j / n for j in range(1, n + 1)]
+            colour = DATASET_COLOURS[i % len(DATASET_COLOURS)]
+            traces.append({
+                "type": "scatter",
+                "mode": "lines",
+                "x": vals,
+                "y": cdf,
+                "name": label,
+                "line": {"color": colour, "width": 2},
+                "showlegend": county == (counties[0] if counties else "All"),
+            })
+        items.append({"div_id": div_id, "title": county, "traces": traces})
+
+    # Render as a 2-column grid
+    parts = ["<div style='display:grid;grid-template-columns:repeat(2,1fr);gap:8px;max-width:100%;'>"]
+    for item in items:
+        did = item["div_id"]
+        parts.append(
+            f"<div style='min-width:0;overflow:hidden;'>"
+            f"<div id='{did}' style='width:100%;height:320px;'></div>"
+            f"<script>Plotly.newPlot('{did}', {json.dumps(item['traces'])}, {{"
+            f"title:{{text:'{esc(item['title'])}',font:{{size:13}}}},"
+            f"xaxis:{{title:'Distance (mi)',range:[0,80]}}, "
+            f"yaxis:{{title:'CDF',range:[0,1],tickformat:'.0%'}}, "
+            f"legend:{{orientation:'h',y:-0.3,x:0.5,xanchor:'center'}}, "
+            f"margin:{{l:45,r:10,t:30,b:55}},"
+            f"height:320"
+            f"}}, {{responsive:true}});</script>"
+            f"</div>"
+        )
+    parts.append("</div>")
+    return "\n".join(parts)

--- a/src/tm1/steps/summaries/calibration/submodels/__init__.py
+++ b/src/tm1/steps/summaries/calibration/submodels/__init__.py
@@ -1,0 +1,1 @@
+"""Submodel summarization functions (pure, no I/O)."""

--- a/src/tm1/steps/summaries/calibration/submodels/atwork_subtour.py
+++ b/src/tm1/steps/summaries/calibration/submodels/atwork_subtour.py
@@ -1,0 +1,123 @@
+"""At-work subtour calibration — TLFD and mode shares for at-work subtours only."""
+
+import logging
+
+import polars as pl
+
+log = logging.getLogger(__name__)
+
+REQUIRED_FIELDS = ("indiv_tour_data", "ao_results", "households", "dist_skim")
+
+# All purpose labels that identify at-work subtours across CTRAMP and ActivitySim
+_ATWORK_PURPOSES = ["atwork_business", "atwork_eat", "atwork_maint", "atwork"]
+
+_MAX_DIST = 25
+
+
+def summarize(
+    indiv_tour_data: pl.DataFrame,
+    ao_results: pl.DataFrame,
+    households: pl.DataFrame,
+    dist_skim: pl.DataFrame,
+    *,
+    weight_col: str | None = None,
+    sampleshare: float = 1.0,
+) -> dict[str, pl.DataFrame]:
+    """At-work subtour calibration summaries.
+
+    Returns dict with keys:
+        ``atwork_tlfd`` — TLFD (distbin × Total) for at-work subtours.
+        ``atwork_avg_trip_length`` — single-row average distance.
+        ``atwork_mode_summary`` — mode shares by auto_sufficiency.
+    """
+    weight = 1.0 / sampleshare
+
+    # Filter to at-work tours only
+    tours = indiv_tour_data.filter(pl.col("tour_purpose").is_in(_ATWORK_PURPOSES))
+    if tours.height == 0:
+        found_purposes = indiv_tour_data["tour_purpose"].unique().sort().to_list()
+        log.warning(
+            "atwork_subtour: found 0 at-work tours in indiv_tour_data "
+            "(n=%d). Expected tour_purpose in %s, but found: %s. "
+            "This is expected for survey data but indicates a bug for "
+            "model output.",
+            indiv_tour_data.height, _ATWORK_PURPOSES, found_purposes,
+        )
+        return {}
+
+    # --- Weight handling ---
+    wcol = weight_col if weight_col is not None else "_weight"
+    if weight_col is None:
+        tours = tours.with_columns(pl.lit(weight).alias("_weight"))
+
+    # --- TLFD: trip length frequency distribution ---
+    dist_col = "DIST" if "DIST" in dist_skim.columns else "dist"
+    skim = dist_skim.select(
+        pl.col("orig").cast(pl.Int64),
+        pl.col("dest").cast(pl.Int64),
+        pl.col(dist_col).cast(pl.Float64).alias("DIST"),
+    )
+    tours_with_dist = tours.join(
+        skim,
+        left_on=["orig_taz", "dest_taz"],
+        right_on=["orig", "dest"],
+        how="left",
+    )
+
+    avg_dist = (
+        tours_with_dist.select(
+            (pl.col("DIST") * pl.col(wcol)).sum() / pl.col(wcol).sum(),
+        ).item()
+    )
+
+    binned = (
+        tours_with_dist.filter(pl.col("DIST").is_not_null())
+        .with_columns(
+            pl.col("DIST").clip(0.5, _MAX_DIST + 0.5).round(0).cast(pl.Int64).alias("distbin"),
+        )
+        .group_by("distbin")
+        .agg(pl.col(wcol).sum().alias("Total"))
+    )
+    all_bins = pl.DataFrame({"distbin": list(range(1, _MAX_DIST + 1))})
+    tlfd = all_bins.join(binned, on="distbin", how="left").fill_null(0).sort("distbin")
+
+    # --- Mode shares by auto sufficiency ---
+    ao = ao_results.select("hh_id", "auto_ownership")
+    hh_info = households.select("hh_id")
+    if "hworkers" in households.columns:
+        hh_info = households.select("hh_id", "hworkers")
+    else:
+        hh_info = hh_info.with_columns(pl.lit(1).alias("hworkers"))
+
+    mode_tours = tours.join(ao, on="hh_id", how="left")
+    mode_tours = mode_tours.join(hh_info.select("hh_id", "hworkers"), on="hh_id", how="left")
+
+    mode_tours = mode_tours.with_columns(
+        pl.when(pl.col("auto_ownership").fill_null(0) == 0)
+        .then(pl.lit("Zero-auto"))
+        .when(
+            pl.col("auto_ownership").fill_null(0)
+            < pl.col("hworkers").fill_null(1)
+        )
+        .then(pl.lit("Autos < Workers"))
+        .otherwise(pl.lit("Autos >= Workers"))
+        .alias("auto_suff"),
+    )
+
+    # Weight expression
+    if weight_col is not None:
+        w_expr = pl.col(weight_col).sum()
+    else:
+        w_expr = pl.col("_weight").sum()
+
+    mode_summary = (
+        mode_tours.group_by("tour_mode", "auto_suff")
+        .agg(w_expr.alias("num_tours"))
+        .sort("tour_mode", "auto_suff")
+    )
+
+    return {
+        "atwork_tlfd": tlfd,
+        "atwork_avg_trip_length": pl.DataFrame([{"avg_trip_length": avg_dist}]),
+        "atwork_mode_summary": mode_summary,
+    }

--- a/src/tm1/steps/summaries/calibration/submodels/auto_ownership.py
+++ b/src/tm1/steps/summaries/calibration/submodels/auto_ownership.py
@@ -1,0 +1,101 @@
+"""Auto ownership calibration — pure summarization logic.
+
+All functions operate on eager ``pl.DataFrame`` inputs and return
+``dict[str, pl.DataFrame]``.  No file I/O, no config, no logging.
+"""
+
+import polars as pl
+
+from tm1.steps.summaries.calibration.enums import CTRAMPCounty
+
+COUNTY_LOOKUP: dict[int, str] = {c.id: c.label for c in CTRAMPCounty}
+
+# Required bundle fields for this submodel.
+REQUIRED_FIELDS = ("households", "ao_results", "taz_data")
+
+
+def summarize(
+    households: pl.DataFrame,
+    ao_results: pl.DataFrame,
+    taz_data: pl.DataFrame,
+    *,
+    sampleshare: float = 1.0,
+) -> dict[str, pl.DataFrame]:
+    """Produce auto-ownership calibration summaries.
+
+    Args:
+        households: Needs hh_id, home_taz.
+        ao_results: Needs hh_id, auto_ownership (vehicle count 0-4).
+        taz_data: Needs zone, county.
+        sampleshare: Uniform weight = 1/sampleshare per record.
+
+    Returns:
+        dict with keys: ``county_summary``, ``taz_long``, ``taz_spread``.
+    """
+    weight = 1.0 / sampleshare
+
+    # Join HH info onto AO results
+    ao = ao_results.join(
+        households.select("hh_id", "home_taz"),
+        on="hh_id",
+        how="left",
+    )
+
+    # Attach county
+    taz_county = taz_data.select(
+        pl.col("zone").cast(pl.Int64),
+        pl.col("county").cast(pl.Int64),
+    )
+    ao = ao.join(
+        taz_county.rename({"zone": "home_taz"}),
+        on="home_taz",
+        how="left",
+    )
+    ao = ao.with_columns(
+        pl.col("county")
+        .replace_strict(COUNTY_LOOKUP, default="Unknown")
+        .alias("county_name"),
+    )
+
+    # -- County summary (County x AO pivot) --------------------------------
+    county_grouped = (
+        ao.group_by("county", "county_name", "auto_ownership")
+        .agg(pl.len().alias("num_hh"))
+        .with_columns((pl.col("num_hh") * weight).alias("num_hh"))
+    )
+    county_summary = (
+        county_grouped.pivot(
+            on="auto_ownership", index=["county", "county_name"], values="num_hh",
+        )
+        .fill_null(0.0)
+        .sort("county")
+    )
+    # Ensure column names are strings
+    county_summary = county_summary.rename(
+        {c: str(c) for c in county_summary.columns if not isinstance(c, str)}
+    )
+
+    # -- TAZ long format ---------------------------------------------------
+    taz_long = (
+        ao.group_by("home_taz", "auto_ownership")
+        .agg(pl.len().alias("num_hh"))
+        .with_columns((pl.col("num_hh") * weight).alias("num_hh"))
+        .rename({"auto_ownership": "num_vehicles"})
+        .sort("home_taz", "num_vehicles")
+    )
+
+    # -- TAZ spread format -------------------------------------------------
+    taz_spread = (
+        taz_long.pivot(on="num_vehicles", index="home_taz", values="num_hh")
+        .fill_null(0.0)
+        .sort("home_taz")
+    )
+    taz_spread = taz_spread.rename(
+        {c: str(c) for c in taz_spread.columns if not isinstance(c, str)}
+    )
+
+    return {
+        "county_summary": county_summary,
+        "taz_long": taz_long,
+        "taz_spread": taz_spread,
+    }

--- a/src/tm1/steps/summaries/calibration/submodels/daily_activity_pattern.py
+++ b/src/tm1/steps/summaries/calibration/submodels/daily_activity_pattern.py
@@ -1,0 +1,81 @@
+"""Coordinated daily activity pattern (CDAP) calibration — pure summarization logic.
+
+All functions operate on eager ``pl.DataFrame`` inputs and return
+``dict[str, pl.DataFrame]``.  No file I/O, no config, no logging.
+"""
+
+import polars as pl
+
+from tm1.steps.summaries.calibration.enums import CTRAMPPersonType
+
+PERSON_TYPE_LOOKUP: dict[str, int] = {pt.label: pt.id for pt in CTRAMPPersonType} # pyright: ignore[reportAssignmentType]
+
+# Required bundle fields for this submodel.
+REQUIRED_FIELDS = ("cdap_results",)
+
+
+def summarize(
+    cdap_results: pl.DataFrame,
+    *,
+    weight_col: str | None = None,
+    sampleshare: float = 1.0,
+) -> dict[str, pl.DataFrame]:
+    """Produce CDAP calibration summaries.
+
+    Args:
+        cdap_results: Activity pattern data with canonical columns
+            ``person_type`` (int id or string label) and
+            ``activity_pattern`` (H/M/N).  May also contain a weight column.
+        weight_col: Per-record weight column.  When *None*, each record gets
+            weight ``1 / sampleshare``.
+        sampleshare: Used to derive uniform weight when *weight_col* is None.
+
+    Returns:
+        dict with key ``person_type_summary``: wide DataFrame with columns
+        ``person_type``, ``H``, ``M``, ``N``.
+    """
+    df = cdap_results
+
+    # Normalize person type column to integer IDs if it contains string labels
+    if df.schema["person_type"] == pl.Utf8:
+        df = df.with_columns(
+            pl.col("person_type")
+            .replace_strict(PERSON_TYPE_LOOKUP, default=None)
+            .alias("person_type"),
+        )
+
+    # Assign weight
+    if weight_col is not None:
+        if weight_col not in df.columns:
+            msg = (
+                f"weight_col {weight_col!r} not found in cdap_results "
+                f"columns: {df.columns}"
+            )
+            raise ValueError(msg)
+        weight = weight_col
+    else:
+        weight = "_weight"
+        df = df.with_columns(pl.lit(1.0 / sampleshare).alias(weight))
+
+    # Aggregate: person_type x activity_pattern -> sum of weights
+    grouped = (
+        df.filter(pl.col("person_type").is_not_null())
+        .group_by("person_type", "activity_pattern")
+        .agg(pl.col(weight).sum().alias("num_pers"))
+    )
+
+    # Pivot to wide: person_type x (H, M, N)
+    wide = (
+        grouped.pivot(on="activity_pattern", index="person_type", values="num_pers")
+        .fill_null(0.0)
+        .sort("person_type")
+    )
+
+    # Ensure H, M, N columns exist
+    for col in ("H", "M", "N"):
+        if col not in wide.columns:
+            wide = wide.with_columns(pl.lit(0.0).alias(col))
+
+    wide = wide.select("person_type", "H", "M", "N")
+
+    return {"person_type_summary": wide}

--- a/src/tm1/steps/summaries/calibration/submodels/nonwork_dest_choice.py
+++ b/src/tm1/steps/summaries/calibration/submodels/nonwork_dest_choice.py
@@ -1,0 +1,130 @@
+"""Non-work destination choice calibration — pure summarization logic.
+
+Produces trip-length frequency distributions and average trip lengths
+for each non-work tour purpose, matching R script ``09_nonwork_destination_choice_TM.R``.
+"""
+
+import polars as pl
+
+REQUIRED_FIELDS = ("indiv_tour_data", "dist_skim")
+
+# Purpose grouping: display_name → list of raw CTRAMP/ActivitySim tour_purpose values
+PURPOSE_GROUPS: dict[str, list[str]] = {
+    "Escort": ["escort_kids", "escort_no kids", "escort"],
+    "Shopping": ["shopping"],
+    "Maintenance": ["othmaint"],
+    "Eating Out": ["eatout"],
+    "Visiting": ["social"],
+    "Discretionary": ["othdiscr"],
+    "At-Work": ["atwork_business", "atwork_eat", "atwork_maint", "atwork"],
+}
+
+_MAX_DIST = 25
+
+
+def _combine_tours(
+    indiv: pl.DataFrame,
+    joint: pl.DataFrame | None,
+    weight_col: str | None,
+    sampleshare: float,
+) -> pl.DataFrame:
+    """Stack individual + joint tours with a weight column.
+
+    If *weight_col* is given it must exist in *indiv* (and *joint* if present).
+    Otherwise a uniform ``_weight = 1/sampleshare`` column is created.
+    """
+    keep = ["hh_id", "tour_purpose", "orig_taz", "dest_taz"]
+    if weight_col is not None:
+        if weight_col not in indiv.columns:
+            msg = (
+                f"weight_col {weight_col!r} not found in indiv_tour_data "
+                f"columns: {indiv.columns}"
+            )
+            raise ValueError(msg)
+        keep.append(weight_col)
+
+    tours = indiv.select(keep)
+    if joint is not None and len(joint) > 0:
+        if weight_col is not None and weight_col not in joint.columns:
+            msg = (
+                f"weight_col {weight_col!r} not found in joint_tour_data "
+                f"columns: {joint.columns}"
+            )
+            raise ValueError(msg)
+        tours = pl.concat([tours, joint.select(keep)])
+
+    if weight_col is None:
+        tours = tours.with_columns(pl.lit(1.0 / sampleshare).alias("_weight"))
+    return tours
+
+
+def summarize(
+    indiv_tour_data: pl.DataFrame,
+    dist_skim: pl.DataFrame,
+    *,
+    joint_tour_data: pl.DataFrame | None = None,
+    weight_col: str | None = None,
+    sampleshare: float = 1.0,
+) -> dict[str, pl.DataFrame]:
+    """Produce non-work destination choice calibration summaries.
+
+    Returns dict with keys:
+        ``nwdc_avg_trip_lengths`` — average distance per purpose.
+        ``nwdc_tlfd_{purpose}``  — TLFD (distbin × Total) per purpose.
+    """
+    weight = 1.0 / sampleshare
+    tours = _combine_tours(indiv_tour_data, joint_tour_data, weight_col, sampleshare)
+    wcol = weight_col if weight_col is not None else "_weight"
+
+    # Join distances
+    # Canonical skim columns after io.py renaming: orig, dest, dist
+    dist_col = "DIST" if "DIST" in dist_skim.columns else "dist"
+    skim = dist_skim.select(
+        pl.col("orig").cast(pl.Int64),
+        pl.col("dest").cast(pl.Int64),
+        pl.col(dist_col).cast(pl.Float64).alias("DIST"),
+    )
+    tours = tours.join(
+        skim,
+        left_on=["orig_taz", "dest_taz"],
+        right_on=["orig", "dest"],
+        how="left",
+    )
+
+    results: dict[str, pl.DataFrame] = {}
+    avg_rows: list[dict] = []
+
+    for display_name, purposes in PURPOSE_GROUPS.items():
+        subset = tours.filter(pl.col("tour_purpose").is_in(purposes))
+        if subset.height == 0:
+            continue
+
+        key = display_name.lower().replace("-", "").replace(" ", "_")
+
+        # Weighted average trip length
+        avg_dist = (
+            subset.select(
+                (pl.col("DIST") * pl.col(wcol)).sum()
+                / pl.col(wcol).sum(),
+            )
+            .item()
+        )
+        avg_rows.append({"purpose": display_name, "avg_trip_length": avg_dist})
+
+        # TLFD: 1-mile bins from 1
+        binned = (
+            subset.filter(pl.col("DIST").is_not_null())
+            .with_columns(
+                pl.col("DIST").clip(0.5, _MAX_DIST + 0.5).round(0).cast(pl.Int64).alias("distbin"),
+            )
+            .group_by("distbin")
+            .agg(pl.col(wcol).sum().alias("Total"))
+        )
+
+        # Ensure all bins present
+        all_bins = pl.DataFrame({"distbin": list(range(1, _MAX_DIST + 1))})
+        tlfd = all_bins.join(binned, on="distbin", how="left").fill_null(0).sort("distbin")
+        results[f"nwdc_tlfd_{key}"] = tlfd
+
+    results["nwdc_avg_trip_lengths"] = pl.DataFrame(avg_rows)
+    return results

--- a/src/tm1/steps/summaries/calibration/submodels/tour_mode_choice.py
+++ b/src/tm1/steps/summaries/calibration/submodels/tour_mode_choice.py
@@ -1,0 +1,178 @@
+"""Tour mode choice calibration — pure summarization logic.
+
+Produces tour-count summaries by (simple_purpose × tour_mode × auto_sufficiency),
+matching R script ``11_tour_mode_choice_TM.R``.
+"""
+
+import polars as pl
+
+from tm1.steps.summaries.calibration.enums import CTRAMPModeType
+
+REQUIRED_FIELDS = ("indiv_tour_data", "ao_results", "households")
+
+# Purpose simplification: raw CTRAMP purpose → simple category
+_SIMPLE_PURPOSE: dict[str, str] = {
+    # CTRAMP purpose names
+    "atwork_business": "At-Work",
+    "atwork_eat": "At-Work",
+    "atwork_maint": "At-Work",
+    "eatout": "Discretionary",
+    "escort_kids": "Maintenance",
+    "escort_no kids": "Maintenance",
+    "othdiscr": "Discretionary",
+    "othmaint": "Maintenance",
+    "school_grade": "School",
+    "school_high": "School",
+    "shopping": "Maintenance",
+    "social": "Discretionary",
+    "university": "University",
+    "work_high": "Work",
+    "work_low": "Work",
+    "work_med": "Work",
+    "work_very high": "Work",
+    # ActivitySim purpose names
+    "atwork": "At-Work",
+    "escort": "Maintenance",
+    "school": "School",
+    "univ": "University",
+    "work": "Work",
+}
+
+MODE_LABELS: dict[int, str] = {m.id: m.label for m in CTRAMPModeType}
+
+
+def _auto_suff(ao: int, hworkers: int) -> str:
+    if ao == 0:
+        return "Zero-auto"
+    if ao < hworkers:
+        return "Autos < Workers"
+    return "Autos >= Workers"
+
+
+def summarize(
+    indiv_tour_data: pl.DataFrame,
+    ao_results: pl.DataFrame,
+    households: pl.DataFrame,
+    *,
+    persons: pl.DataFrame | None = None,
+    joint_tour_data: pl.DataFrame | None = None,
+    weight_col: str | None = None,
+    sampleshare: float = 1.0,
+) -> dict[str, pl.DataFrame]:
+    """Tour mode choice calibration summary.
+
+    Returns dict with key ``tour_mode_summary``:
+        Columns: simple_purpose, tour_mode, tour_mode_label, auto_suff, num_tours.
+    """
+    weight = 1.0 / sampleshare
+
+    # Reclassify ActivitySim "school" tours for university students (ptype 3)
+    # CTRAMP has separate purposes (school_grade, school_high, university) but
+    # ActivitySim labels all as "school" regardless of person type.
+    if (
+        persons is not None
+        and "person_id" in indiv_tour_data.columns
+        and "ptype" in persons.columns
+        and "person_id" in persons.columns
+    ):
+        ptype_map = persons.select("person_id", "ptype")
+        indiv_tour_data = indiv_tour_data.join(ptype_map, on="person_id", how="left")
+        indiv_tour_data = indiv_tour_data.with_columns(
+            pl.when((pl.col("tour_purpose") == "school") & (pl.col("ptype") == 3))
+            .then(pl.lit("univ"))
+            .otherwise(pl.col("tour_purpose"))
+            .alias("tour_purpose"),
+        ).drop("ptype")
+
+    # Validate weight_col up front if specified
+    if weight_col is not None and weight_col not in indiv_tour_data.columns:
+        msg = (
+            f"weight_col {weight_col!r} not found in indiv_tour_data "
+            f"columns: {indiv_tour_data.columns}"
+        )
+        raise ValueError(msg)
+
+    # Stack indiv + joint tours
+    indiv_cols = ["hh_id", "tour_purpose", "tour_mode"]
+    if weight_col is not None:
+        indiv_cols.append(weight_col)
+    indiv = indiv_tour_data.select(indiv_cols).with_columns(
+        pl.lit(1).cast(pl.UInt32).alias("num_participants"),
+    )
+
+    if joint_tour_data is not None and len(joint_tour_data) > 0:
+        jcols = ["hh_id", "tour_purpose", "tour_mode"]
+        if weight_col is not None:
+            if weight_col not in joint_tour_data.columns:
+                msg = (
+                    f"weight_col {weight_col!r} not found in joint_tour_data "
+                    f"columns: {joint_tour_data.columns}"
+                )
+                raise ValueError(msg)
+            jcols.append(weight_col)
+        # joint tours: count participants via tour_participants if available
+        if "tour_participants" in joint_tour_data.columns:
+            joint = joint_tour_data.select(
+                [c for c in jcols if c in joint_tour_data.columns]
+                + ["tour_participants"],
+            ).with_columns(
+                pl.col("tour_participants")
+                .cast(pl.Utf8)
+                .str.split(" ")
+                .list.len()
+                .alias("num_participants"),
+            ).drop("tour_participants")
+        else:
+            joint = joint_tour_data.select(
+                [c for c in jcols if c in joint_tour_data.columns],
+            ).with_columns(pl.lit(1).cast(pl.UInt32).alias("num_participants"))
+        tours = pl.concat([indiv, joint])
+    else:
+        tours = indiv
+
+    # Add auto sufficiency via AO + HH workers
+    hh_info = households.select("hh_id", "home_taz")
+    if "hworkers" in households.columns:
+        hh_info = households.select("hh_id", "home_taz", "hworkers")
+    elif "PERSONS" in households.columns:
+        hh_info = households.select("hh_id", "home_taz").with_columns(
+            pl.lit(1).alias("hworkers"),
+        )
+    else:
+        hh_info = hh_info.with_columns(pl.lit(1).alias("hworkers"))
+
+    ao = ao_results.select("hh_id", "auto_ownership")
+    tours = tours.join(ao, on="hh_id", how="left")
+    tours = tours.join(hh_info.select("hh_id", "hworkers"), on="hh_id", how="left")
+
+    tours = tours.with_columns(
+        pl.when(pl.col("auto_ownership").fill_null(0) == 0)
+        .then(pl.lit("Zero-auto"))
+        .when(
+            pl.col("auto_ownership").fill_null(0)
+            < pl.col("hworkers").fill_null(1)
+        )
+        .then(pl.lit("Autos < Workers"))
+        .otherwise(pl.lit("Autos >= Workers"))
+        .alias("auto_suff"),
+        pl.col("tour_purpose")
+        .replace_strict(_SIMPLE_PURPOSE, default="Other")
+        .alias("simple_purpose"),
+        pl.col("tour_mode")
+        .replace_strict(MODE_LABELS, default="Unknown")
+        .alias("tour_mode_label"),
+    )
+
+    # Weight column
+    if weight_col is not None:
+        w_expr = (pl.col(weight_col) * pl.col("num_participants")).sum()
+    else:
+        w_expr = (pl.lit(weight) * pl.col("num_participants")).sum()
+
+    summary = (
+        tours.group_by("simple_purpose", "tour_mode", "tour_mode_label", "auto_suff")
+        .agg(w_expr.alias("num_tours"))
+        .sort("simple_purpose", "tour_mode", "auto_suff")
+    )
+
+    return {"tour_mode_summary": summary}

--- a/src/tm1/steps/summaries/calibration/submodels/trip_mode_choice.py
+++ b/src/tm1/steps/summaries/calibration/submodels/trip_mode_choice.py
@@ -1,0 +1,109 @@
+"""Trip mode choice calibration — pure summarization logic.
+
+Produces trip-count summaries by (simple_purpose × trip_mode),
+matching R script ``15_trip_mode_choice_TM.R``.
+"""
+
+import polars as pl
+
+from tm1.steps.summaries.calibration.enums import CTRAMPModeType
+
+REQUIRED_FIELDS = ("indiv_trip_data",)
+
+# Purpose simplification: raw CTRAMP purpose → simple category
+_SIMPLE_PURPOSE: dict[str, str] = {
+    # CTRAMP purpose names
+    "atwork_business": "At-Work",
+    "atwork_eat": "At-Work",
+    "atwork_maint": "At-Work",
+    "eatout": "Discretionary",
+    "escort_kids": "Maintenance",
+    "escort_no kids": "Maintenance",
+    "othdiscr": "Discretionary",
+    "othmaint": "Maintenance",
+    "school_grade": "School",
+    "school_high": "School",
+    "shopping": "Maintenance",
+    "social": "Discretionary",
+    "university": "University",
+    "work_high": "Work",
+    "work_low": "Work",
+    "work_med": "Work",
+    "work_very high": "Work",
+    # ActivitySim purpose names
+    "atwork": "At-Work",
+    "escort": "Maintenance",
+    "school": "School",
+    "univ": "University",
+    "work": "Work",
+}
+
+MODE_LABELS: dict[int, str] = {m.id: m.label for m in CTRAMPModeType}
+
+
+def summarize(
+    indiv_trip_data: pl.DataFrame,
+    *,
+    joint_trip_data: pl.DataFrame | None = None,
+    weight_col: str | None = None,
+    sampleshare: float = 1.0,
+) -> dict[str, pl.DataFrame]:
+    """Trip mode choice calibration summary.
+
+    Returns dict with key ``trip_mode_summary``:
+        Columns: simple_purpose, trip_mode, trip_mode_label, num_trips.
+    """
+    weight = 1.0 / sampleshare
+
+    # Validate weight_col up front if specified
+    if weight_col is not None and weight_col not in indiv_trip_data.columns:
+        msg = (
+            f"weight_col {weight_col!r} not found in indiv_trip_data "
+            f"columns: {indiv_trip_data.columns}"
+        )
+        raise ValueError(msg)
+
+    # Stack indiv + joint trips
+    base_cols = ["hh_id", "tour_purpose", "trip_mode"]
+    if weight_col is not None:
+        base_cols.append(weight_col)
+
+    indiv = indiv_trip_data.select(base_cols).with_columns(
+        pl.lit(1).cast(pl.Int64).alias("num_participants"),
+    )
+
+    if joint_trip_data is not None:
+        jcols = [c for c in base_cols if c in joint_trip_data.columns]
+        if "num_participants" in joint_trip_data.columns:
+            joint = joint_trip_data.select(jcols + ["num_participants"])
+        else:
+            joint = joint_trip_data.select(jcols).with_columns(
+                pl.lit(1).alias("num_participants"),
+            )
+        trips = pl.concat([indiv, joint])
+    else:
+        trips = indiv
+
+    trips = trips.with_columns(
+        pl.col("tour_purpose")
+        .replace_strict(_SIMPLE_PURPOSE, default="Other")
+        .alias("simple_purpose"),
+        pl.col("trip_mode")
+        .cast(pl.Int64)
+        .replace_strict(MODE_LABELS, default="Unknown")
+        .alias("trip_mode_label"),
+    )
+
+    # Weight
+    if weight_col is not None:
+        w_expr = (pl.col(weight_col) * pl.col("num_participants")).sum()
+    else:
+        w_expr = (pl.lit(weight) * pl.col("num_participants")).sum()
+
+    summary = (
+        trips.group_by("simple_purpose", "trip_mode", "trip_mode_label")
+        .agg(w_expr.alias("num_trips"))
+        .sort("simple_purpose", "trip_mode")
+    )
+
+    return {"trip_mode_summary": summary}

--- a/src/tm1/steps/summaries/calibration/submodels/work_from_home.py
+++ b/src/tm1/steps/summaries/calibration/submodels/work_from_home.py
@@ -1,0 +1,134 @@
+"""Work from home calibration — pure summarization logic.
+
+All functions operate on eager ``pl.DataFrame`` inputs and return
+``dict[str, pl.DataFrame]``.  No file I/O, no config, no logging.
+"""
+
+import polars as pl
+
+from tm1.steps.summaries.calibration.enums import CTRAMPCounty
+
+COUNTY_LOOKUP: dict[int, str] = {c.id: c.label for c in CTRAMPCounty}
+
+# Required bundle fields for this submodel.
+REQUIRED_FIELDS = ("cdap_results", "households", "taz_data")
+
+
+def summarize(
+    cdap_results: pl.DataFrame,
+    households: pl.DataFrame,
+    taz_data: pl.DataFrame,
+    *,
+    sampleshare: float = 1.0,
+) -> dict[str, pl.DataFrame]:
+    """Produce WFH calibration summaries.
+
+    Args:
+        cdap_results: Person-level data with ``hh_id``, ``person_type`` or
+            ``ptype``, and ``work_from_home`` (0/1 or bool).
+        households: Needs ``hh_id``, ``home_taz``.
+        taz_data: Needs ``zone``, ``county``.
+        sampleshare: Uniform weight = 1/sampleshare per record.
+
+    Returns:
+        dict with keys: ``county_summary``, ``overall_summary``.
+    """
+    weight = 1.0 / sampleshare
+
+    # Determine person type column
+    ptype_col = "person_type" if "person_type" in cdap_results.columns else "ptype"
+
+    # Filter to workers only (ptype 1 or 2, or labels containing worker)
+    workers = cdap_results.filter(_worker_filter(ptype_col))
+
+    # Ensure work_from_home is numeric
+    if "work_from_home" not in workers.columns:
+        # No WFH data available — return empty summaries
+        return {
+            "county_summary": pl.DataFrame(schema={"county": pl.Int64, "county_name": pl.Utf8, "workers": pl.Float64, "wfh": pl.Float64, "wfh_rate": pl.Float64}),
+            "overall_summary": pl.DataFrame(schema={"category": pl.Utf8, "workers": pl.Float64, "wfh": pl.Float64, "wfh_rate": pl.Float64}),
+        }
+
+    workers = workers.with_columns(
+        pl.col("work_from_home").cast(pl.Int64).alias("wfh_flag"),
+    )
+
+    # Join home_taz from households
+    workers = workers.join(
+        households.select("hh_id", "home_taz"),
+        on="hh_id",
+        how="left",
+    )
+
+    # Join county from taz_data
+    taz_county = taz_data.select(
+        pl.col("zone").cast(pl.Int64),
+        pl.col("county").cast(pl.Int64),
+    )
+    workers = workers.join(
+        taz_county.rename({"zone": "home_taz"}),
+        on="home_taz",
+        how="left",
+    )
+    workers = workers.with_columns(
+        pl.col("county")
+        .replace_strict(COUNTY_LOOKUP, default="Unknown")
+        .alias("county_name"),
+    )
+
+    # -- County summary ----------------------------------------------------
+    county_summary = (
+        workers.group_by("county", "county_name")
+        .agg(
+            (pl.len() * weight).alias("workers"),
+            (pl.col("wfh_flag").sum() * weight).alias("wfh"),
+        )
+        .with_columns(
+            (pl.col("wfh") / pl.col("workers")).alias("wfh_rate"),
+        )
+        .sort("county")
+    )
+
+    # -- Overall summary (by person type) ----------------------------------
+    overall_summary = (
+        workers.group_by(ptype_col)
+        .agg(
+            (pl.len() * weight).alias("workers"),
+            (pl.col("wfh_flag").sum() * weight).alias("wfh"),
+        )
+        .with_columns(
+            (pl.col("wfh") / pl.col("workers")).alias("wfh_rate"),
+        )
+        .rename({ptype_col: "category"})
+        .with_columns(pl.col("category").cast(pl.Utf8))
+        .sort("category")
+    )
+
+    # Normalize category labels to consistent names
+    _PTYPE_LABELS = {"1": "Full-time worker", "2": "Part-time worker"}
+    overall_summary = overall_summary.with_columns(
+        pl.col("category").replace_strict(_PTYPE_LABELS, default=pl.col("category")).alias("category"),
+    )
+
+    # Add total row
+    total = pl.DataFrame({
+        "category": ["Total"],
+        "workers": [county_summary["workers"].sum()],
+        "wfh": [county_summary["wfh"].sum()],
+        "wfh_rate": [county_summary["wfh"].sum() / county_summary["workers"].sum()],
+    })
+    overall_summary = pl.concat([overall_summary, total])
+
+    return {
+        "county_summary": county_summary,
+        "overall_summary": overall_summary,
+    }
+
+
+def _worker_filter(ptype_col: str) -> pl.Expr:
+    """Return filter expression for workers (FT=1, PT=2 or string labels)."""
+    col = pl.col(ptype_col)
+    return (
+        col.cast(pl.Utf8).is_in(["1", "2"])
+        | col.cast(pl.Utf8).str.contains("(?i)^(full-time|part-time) worker$")
+    )

--- a/src/tm1/steps/summaries/calibration/submodels/work_school_location.py
+++ b/src/tm1/steps/summaries/calibration/submodels/work_school_location.py
@@ -1,0 +1,342 @@
+"""Usual work and school location calibration — pure summarization logic.
+
+All functions operate on eager ``pl.DataFrame`` inputs (already collected from
+the bundle) and return ``dict[str, pl.DataFrame]``.  No file I/O, no config
+objects, no logging side-effects.
+"""
+
+import polars as pl
+
+from tm1.steps.summaries.calibration.enums import CTRAMPCounty
+
+COUNTY_LOOKUP: dict[int, str] = {c.id: c.label for c in CTRAMPCounty}
+COUNTY_IDS: list[int] = sorted(COUNTY_LOOKUP)
+COUNTY_NAMES: list[str] = [COUNTY_LOOKUP[i] for i in COUNTY_IDS]
+
+# Required bundle fields for this submodel.
+REQUIRED_FIELDS = ("wsloc_results", "taz_data", "dist_skim")
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def summarize(
+    wsloc: pl.DataFrame,
+    taz_data: pl.DataFrame,
+    dist_skim: pl.DataFrame,
+    *,
+    weight_col: str | None = None,
+    sampleshare: float = 1.0,
+    max_bin: int = 80,
+) -> dict[str, pl.DataFrame]:
+    """Produce work/school location calibration summaries.
+
+    Args:
+        wsloc: wsLocResults table (canonical columns).  Needs at minimum
+            home_taz, work_location, school_location, student_category.
+            May also contain *weight_col*.
+        taz_data: Must have zone and county columns.
+        dist_skim: Three columns — orig, dest, dist.
+        weight_col: Per-record weight column name (e.g. "person_weight").
+            When *None*, each record gets weight ``1 / sampleshare``.
+        sampleshare: Used to derive uniform weight when *weight_col* is None.
+        max_bin: Upper limit for TLFD distance bins (exclusive).
+
+    Returns:
+        dict with keys: ``county_summary``, ``trip_tlfd_work``,
+        ``trip_tlfd_univ``, ``trip_tlfd_school``, ``avg_trip_lengths``.
+    """
+    # -- uniform weight if no per-record column ----------------------------
+    if weight_col is not None:
+        if weight_col not in wsloc.columns:
+            msg = (
+                f"weight_col {weight_col!r} not found in wsloc_results "
+                f"columns: {wsloc.columns}"
+            )
+            raise ValueError(msg)
+    else:
+        weight_col = "_weight"
+        wsloc = wsloc.with_columns(pl.lit(1.0 / sampleshare).alias(weight_col))
+
+    taz_county = taz_data.select(
+        pl.col("zone").cast(pl.Int64),
+        pl.col("county").cast(pl.Int64),
+    )
+
+    # -- attach county info for Home, Work, School -------------------------
+    wsloc = _join_county(wsloc, taz_county, "home_taz", "home_county")
+    wsloc = _join_county(wsloc, taz_county, "work_location", "work_county")
+    wsloc = _join_county(wsloc, taz_county, "school_location", "school_county")
+
+    # -- attach distances --------------------------------------------------
+    wsloc = wsloc.join(
+        dist_skim.select(
+            pl.col("orig").cast(pl.Int64).alias("home_taz"),
+            pl.col("dest").cast(pl.Int64).alias("work_location"),
+            pl.col("dist").alias("work_dist"),
+        ),
+        on=["home_taz", "work_location"],
+        how="left",
+    )
+    wsloc = wsloc.join(
+        dist_skim.select(
+            pl.col("orig").cast(pl.Int64).alias("home_taz"),
+            pl.col("dest").cast(pl.Int64).alias("school_location"),
+            pl.col("dist").alias("school_dist"),
+        ),
+        on=["home_taz", "school_location"],
+        how="left",
+    )
+
+    # -- county summary (Home x Work) --------------------------------------
+    county_summary = _county_summary(wsloc, weight_col)
+
+    # -- trip length frequency distributions --------------------------------
+    bins = list(range(1, max_bin))
+    trip_tlfds: dict[str, pl.DataFrame] = {}
+    avg_rows: list[dict] = []
+
+    for trip_type, dist_col, filter_expr in _trip_type_filters():
+        subset = wsloc.filter(filter_expr)
+        tlfd, avgs = _build_tlfd(subset, dist_col, weight_col, bins)
+        trip_tlfds[trip_type] = tlfd
+        avg_rows.extend({"county": a[0], "trip_type": trip_type, "mean": a[1]} for a in avgs)
+
+    # -- average trip lengths (county x trip_type pivot) --------------------
+    avg_df = pl.DataFrame(avg_rows)
+    if avg_df.height > 0:
+        avg_trip_lengths = avg_df.pivot(on="trip_type", index="county", values="mean")
+        # Ensure expected column order
+        desired = ["county"] + [
+            c for c in ("work", "univ", "school") if c in avg_trip_lengths.columns
+        ]
+        avg_trip_lengths = avg_trip_lengths.select(desired)
+    else:
+        avg_trip_lengths = pl.DataFrame({"county": [], "work": [], "univ": [], "school": []})
+
+    # -- raw distance samples for violin / CDF plots ----------------------
+    dist_samples: dict[str, pl.DataFrame] = {}
+    max_violin = 100.0  # cap for display
+    max_sample = 5000   # per county, for browser performance
+    for trip_type, dist_col, filter_expr in _trip_type_filters():
+        subset = (
+            wsloc.filter(filter_expr & pl.col(dist_col).is_not_null())
+            .with_columns(
+                pl.col("home_county")
+                .replace_strict(COUNTY_LOOKUP, default="Unknown")
+                .alias("county"),
+            )
+            .select("county", pl.col(dist_col).clip(0, max_violin).alias("dist"))
+        )
+        # Subsample per county to keep payload manageable
+        sampled = subset.group_by("county").map_groups(
+            lambda g: g.sample(min(len(g), max_sample), seed=42)
+        )
+        dist_samples[trip_type] = sampled
+
+    # -- WFH-split work distance parity ------------------------------------
+    # Mean home->work distance for work-from-home vs regular workers. Both
+    # CTRAMP and ActivitySim keep a usual-workplace TAZ for WFH workers, so a
+    # faithful WFH model should reproduce the (higher) WFH-worker distance.
+    wfh_split = _wfh_split_work(wsloc, weight_col)
+
+    return {
+        "county_summary": county_summary,
+        "trip_tlfd_work": trip_tlfds.get("work"),
+        "trip_tlfd_univ": trip_tlfds.get("univ"),
+        "trip_tlfd_school": trip_tlfds.get("school"),
+        "avg_trip_lengths": avg_trip_lengths,
+        "wfh_split_work": wfh_split,
+        "dist_samples_work": dist_samples.get("work"),
+        "dist_samples_univ": dist_samples.get("univ"),
+        "dist_samples_school": dist_samples.get("school"),
+    }
+
+
+def _wfh_split_work(wsloc: pl.DataFrame, weight_col: str) -> pl.DataFrame | None:
+    """Weighted mean work distance split by work-from-home status.
+
+    Returns a 2-row frame (category, workers, mean_dist), or None when the
+    dataset carries no work_from_home column. In a full run every dataset has
+    one (BATS + CTRAMP supply wfh_choice, ActivitySim the work_from_home model),
+    so None only arises on a partial run that stops before work_from_home --
+    e.g. a location-models-only or early-ablation run.
+    """
+    if "work_from_home" not in wsloc.columns:
+        return None
+    workers = wsloc.filter(
+        (pl.col("work_location") > 0) & pl.col("work_dist").is_not_null()
+    )
+    if workers.height == 0:
+        return None
+    split = (
+        workers.group_by(pl.col("work_from_home").cast(pl.Int64))
+        .agg(
+            (pl.col(weight_col).sum()).alias("workers"),
+            (
+                (pl.col("work_dist") * pl.col(weight_col)).sum()
+                / pl.col(weight_col).sum()
+            ).alias("mean_dist"),
+        )
+        .with_columns(
+            pl.col("work_from_home")
+            .replace_strict({0: "Regular", 1: "Work-from-home"}, default="Unknown")
+            .alias("category"),
+        )
+        .select("category", "workers", "mean_dist")
+        .sort("category")
+    )
+    return split
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _join_county(
+    df: pl.DataFrame,
+    taz_county: pl.DataFrame,
+    taz_col: str,
+    county_col: str,
+) -> pl.DataFrame:
+    """Left-join county onto *df* via *taz_col*, naming result *county_col*."""
+    return df.join(
+        taz_county.rename({"zone": taz_col, "county": county_col}),
+        on=taz_col,
+        how="left",
+    )
+
+
+def _county_name(county_id: int) -> str:
+    return COUNTY_LOOKUP.get(county_id, f"Unknown({county_id})")
+
+
+def _county_summary(wsloc: pl.DataFrame, weight_col: str) -> pl.DataFrame:
+    """Home county x Work county weighted cross-tabulation."""
+    grouped = (
+        wsloc.group_by("home_county", "work_county")
+        .agg(pl.col(weight_col).sum().alias("num_pers"))
+    )
+    # Pivot to wide: home_county rows x work_county columns
+    pivot = grouped.pivot(on="work_county", index="home_county", values="num_pers")
+
+    # Ensure all counties present as rows and columns
+    for cid in COUNTY_IDS:
+        col = str(cid)
+        if col not in pivot.columns:
+            pivot = pivot.with_columns(pl.lit(0.0).alias(col))
+
+    # Reorder and rename
+    pivot = pivot.sort("home_county")
+    # Add home_county_name
+    pivot = pivot.with_columns(
+        pl.col("home_county")
+        .replace_strict(COUNTY_LOOKUP, default="Unknown")
+        .alias("home_county_name"),
+    )
+    # Rename numeric county columns to names
+    renames = {str(cid): COUNTY_LOOKUP[cid] for cid in COUNTY_IDS}
+    pivot = pivot.rename(renames)
+    # Select final column order
+    cols = ["home_county_name", *COUNTY_NAMES]
+    return pivot.select(cols).fill_null(0.0)
+
+
+def _trip_type_filters() -> list[tuple[str, str, pl.Expr]]:
+    """Return ``(trip_type, dist_col, filter_expr)`` triples."""
+    return [
+        ("work", "work_dist", pl.col("work_location") > 0),
+        (
+            "univ",
+            "school_dist",
+            (pl.col("school_location") > 0) & (pl.col("student_category") == "College or higher"),
+        ),
+        (
+            "school",
+            "school_dist",
+            (pl.col("school_location") > 0)
+            & (pl.col("student_category") == "Grade or high school"),
+        ),
+    ]
+
+
+def _build_tlfd(
+    subset: pl.DataFrame,
+    dist_col: str,
+    weight_col: str,
+    bins: list[int],
+) -> tuple[pl.DataFrame, list[tuple[str, float]]]:
+    """Build per-county + Total TLFD for one trip type.
+
+    Returns:
+        Tuple of (tlfd DataFrame with distbin + county columns + Total,
+        list of (county_name_or_Total, weighted_mean) pairs).
+    """
+    # Start with distbin scaffold
+    tlfd = pl.DataFrame({"distbin": bins})
+    avgs: list[tuple[str, float]] = []
+
+    if subset.height == 0:
+        return tlfd.with_columns(pl.lit(0.0).alias("Total")), avgs
+
+    # Add home_county_name for grouping
+    subset = subset.with_columns(
+        pl.col("home_county")
+        .replace_strict(COUNTY_LOOKUP, default="Unknown")
+        .alias("home_county_name"),
+    )
+
+    for county_name in COUNTY_NAMES:
+        county_data = subset.filter(pl.col("home_county_name") == county_name)
+        if county_data.height == 0:
+            continue
+        hist = _weighted_histogram(county_data, dist_col, weight_col, bins)
+        tlfd = tlfd.join(hist.rename({"count": county_name}), on="distbin", how="left")
+        avg = _weighted_mean(county_data, dist_col, weight_col)
+        avgs.append((county_name, avg))
+
+    # Total
+    hist = _weighted_histogram(subset, dist_col, weight_col, bins)
+    tlfd = tlfd.join(hist.rename({"count": "Total"}), on="distbin", how="left")
+    avg = _weighted_mean(subset, dist_col, weight_col)
+    avgs.append(("Total", avg))
+
+    return tlfd.fill_null(0.0), avgs
+
+
+def _weighted_histogram(
+    df: pl.DataFrame,
+    value_col: str,
+    weight_col: str,
+    bins: list[int],
+) -> pl.DataFrame:
+    """Weighted histogram using polars cut + groupby."""
+    max_bin = max(bins)
+    binned = (
+        df.filter(pl.col(value_col).is_not_null())
+        .with_columns(
+            pl.col(value_col).clip(0, max_bin).cast(pl.Int64).alias("_bin"),
+        )
+        # Bin value: floor to int, clamp to [1, max_bin]
+        .with_columns(
+            pl.when(pl.col("_bin") < 1).then(1).otherwise(pl.col("_bin")).alias("_bin"),
+        )
+        .group_by("_bin")
+        .agg(pl.col(weight_col).sum().alias("count"))
+    )
+    # Join back to full bin list
+    scaffold = pl.DataFrame({"distbin": bins})
+    return scaffold.join(
+        binned.rename({"_bin": "distbin"}),
+        on="distbin",
+        how="left",
+    ).with_columns(pl.col("count").fill_null(0.0))
+
+
+def _weighted_mean(df: pl.DataFrame, value_col: str, weight_col: str) -> float:
+    """Weighted mean of *value_col* using *weight_col*."""
+    result = df.filter(pl.col(value_col).is_not_null()).select(
+        (pl.col(value_col) * pl.col(weight_col)).sum() / pl.col(weight_col).sum()
+    )
+    return result.item() if result.height > 0 else 0.0

--- a/src/tm1/steps/summaries/ctramp_output.py
+++ b/src/tm1/steps/summaries/ctramp_output.py
@@ -1,0 +1,338 @@
+"""ActivitySim → CTRAMP output converter.
+
+Temporary shim converter.
+
+Shared by core_summaries and calibration_summaries.  Reads ActivitySim
+``final_*.csv`` outputs and writes CTRAMP-format CSVs into a ``main/``
+directory that downstream R (or Python) summaries expect.
+
+Column mapping is documented in ``docs/OUTPUT_MAPPING.md``.
+"""
+
+import logging
+from pathlib import Path
+
+import polars as pl
+
+log = logging.getLogger(__name__)
+
+# ActivitySim ptype int → CTRAMP person-type text labels
+PTYPE_LABELS = {
+    1: "Full-time worker",
+    2: "Part-time worker",
+    3: "University student",
+    4: "Nonworker",
+    5: "Retired",
+    6: "Driving-age child",
+    7: "Pre-driving-age child",
+    8: "Child too young for school",
+}
+
+# ActivitySim mode label → CTRAMP integer code (1-indexed).
+# Order matches tour_mode_choice.csv / trip_mode_choice.csv column headers.
+MODE_TO_INT: dict[str, int] = {
+    "DRIVEALONEFREE": 1,
+    "DRIVEALONEPAY": 2,
+    "SHARED2FREE": 3,
+    "SHARED2PAY": 4,
+    "SHARED3FREE": 5,
+    "SHARED3PAY": 6,
+    "WALK": 7,
+    "BIKE": 8,
+    "WALK_LOC": 9,
+    "WALK_LRF": 10,
+    "WALK_EXP": 11,
+    "WALK_HVY": 12,
+    "WALK_COM": 13,
+    "DRIVE_LOC": 14,
+    "DRIVE_LRF": 15,
+    "DRIVE_EXP": 16,
+    "DRIVE_HVY": 17,
+    "DRIVE_COM": 18,
+    "TAXI": 19,
+    "TNC_SINGLE": 20,
+    "TNC_SHARED": 21,
+}
+
+
+def export_ctramp_csvs(output_dir: Path, work_dir: Path, iter_label: str) -> None:  # noqa: PLR0915
+    """Read ActivitySim outputs and write CTRAMP-format CSVs into ``work_dir/main/``.
+
+    Parameters
+    ----------
+    output_dir : Path
+        Directory containing ActivitySim ``final_*.csv`` files.
+    work_dir : Path
+        Root of the CTRAMP layout.  CSVs are written to ``work_dir/main/``.
+    iter_label : str
+        Iteration label for filenames (e.g. ``"1"``).
+    """
+    main = work_dir / "main"
+    main.mkdir(parents=True, exist_ok=True)
+
+    # --- Load ActivitySim outputs ---
+    hh = pl.read_csv(output_dir / "final_households.csv")
+    per = pl.read_csv(output_dir / "final_persons.csv")
+    tours = pl.read_csv(output_dir / "final_tours.csv")
+    trips = pl.read_csv(output_dir / "final_trips.csv")
+
+    # --- person_num: row number within household ---
+    per = per.with_columns(
+        pl.col("person_id").rank("ordinal").over("household_id").cast(pl.Int32).alias("person_num")
+    )
+
+    # sample_rate lives on hh only in ActivitySim; propagate to per & tours
+    hh_sr = hh.select("household_id", "sample_rate")
+    per = per.join(hh_sr, on="household_id", how="left")
+    tours = tours.join(hh_sr, on="household_id", how="left", suffix="_hh")
+
+    # Convert mode labels (strings) → CTRAMP integer codes
+    tours = tours.with_columns(
+        pl.col("tour_mode").replace_strict(MODE_TO_INT, default=0).alias("tour_mode")
+    )
+    trips = trips.with_columns(
+        pl.col("trip_mode").replace_strict(MODE_TO_INT, default=0).alias("trip_mode")
+    )
+
+    # -----------------------------------------------------------------
+    # householdData
+    # -----------------------------------------------------------------
+    household_data = hh.select(
+        pl.col("household_id").alias("hh_id"),
+        pl.col("home_zone_id").alias("taz"),
+        pl.lit(0)
+        .cast(pl.Int32)
+        .alias("walk_subzone"),  # TODO: needs walkAccessBuffers; affects JourneyToWork group-by
+        pl.col("income"),
+        pl.col("auto_ownership").alias("autos"),
+        pl.col("hhsize").alias("size"),
+        pl.col("num_workers").alias("workers"),
+        pl.col("sample_rate").alias("sampleRate"),
+    )
+    household_data.write_csv(main / f"householdData_{iter_label}.csv")
+    log.info("  Wrote householdData_%s.csv (%d rows)", iter_label, len(household_data))
+
+    # -----------------------------------------------------------------
+    # personData
+    # -----------------------------------------------------------------
+    person_data = per.select(
+        pl.col("household_id").alias("hh_id"),
+        pl.col("person_id"),
+        pl.col("person_num"),
+        pl.col("age"),
+        pl.col("sex")
+        .map_elements(lambda v: "m" if v == 1 else "f", return_dtype=pl.Utf8)
+        .alias("gender"),
+        pl.col("ptype").replace_strict(PTYPE_LABELS, default="Unknown").alias("type"),
+        pl.col("value_of_time"),
+        pl.col("free_parking_at_work").alias("fp_choice"),
+        pl.col("cdap_activity").alias("activity_pattern"),
+        pl.col("mandatory_tour_frequency").alias("imf_choice"),
+        pl.col("non_mandatory_tour_frequency").alias("inmf_choice"),
+        pl.col("sample_rate").alias("sampleRate"),
+        pl.lit(0).cast(pl.Int32).alias("wfh_choice"),  # TODO: not yet modeled in ActivitySim
+    )
+    person_data.write_csv(main / f"personData_{iter_label}.csv")
+    log.info("  Wrote personData_%s.csv (%d rows)", iter_label, len(person_data))
+
+    # -----------------------------------------------------------------
+    # Tour columns shared by indiv / joint
+    # -----------------------------------------------------------------
+    tour_cols = [
+        pl.col("household_id").alias("hh_id"),
+        pl.col("person_id"),
+        pl.col("tour_id"),
+        pl.col("primary_purpose").alias("tour_purpose"),
+        pl.col("tour_category"),
+        pl.col("origin").alias("orig_taz"),
+        pl.col("destination").alias("dest_taz"),
+        pl.col("start").alias("start_hour"),
+        pl.col("end").alias("end_hour"),
+        pl.col("tour_mode"),
+    ]
+
+    # -----------------------------------------------------------------
+    # indivTourData
+    # -----------------------------------------------------------------
+    indiv_tours = tours.filter(pl.col("tour_category") != "joint")
+    tour_per_num = per.select("person_id", "person_num", "ptype")
+    indiv_tours_j = indiv_tours.join(tour_per_num, on="person_id", how="left")
+    indiv_tour_data = indiv_tours_j.select(
+        *tour_cols,
+        pl.col("person_num"),
+        pl.col("ptype").alias("person_type"),
+        pl.col("stop_frequency").alias("atWork_freq"),  # R drops this; must exist
+        pl.col("sample_rate").alias("sampleRate"),
+    )
+    indiv_tour_data.write_csv(main / f"indivTourData_{iter_label}.csv")
+    log.info("  Wrote indivTourData_%s.csv (%d rows)", iter_label, len(indiv_tour_data))
+
+    # -----------------------------------------------------------------
+    # jointTourData
+    # -----------------------------------------------------------------
+    joint_tours = tours.filter(pl.col("tour_category") == "joint")
+    # tour_participants: space-separated person_nums (R unwinds these)
+    jtp_csv = output_dir / "final_joint_tour_participants.csv"
+    if jtp_csv.exists():
+        jtp = pl.read_csv(jtp_csv)
+        jtp_with_num = jtp.join(per.select("person_id", "person_num"), on="person_id", how="left")
+        tour_parts = (
+            jtp_with_num.sort("tour_id", "person_num")
+            .group_by("tour_id")
+            .agg(pl.col("person_num").cast(pl.Utf8).str.concat(" ").alias("tour_participants"))
+        )
+        joint_tours = joint_tours.join(tour_parts, on="tour_id", how="left")
+    else:
+        log.warning("No final_joint_tour_participants.csv — tour_participants will be empty")
+        joint_tours = joint_tours.with_columns(pl.lit("").alias("tour_participants"))
+
+    joint_tour_data = joint_tours.select(
+        pl.col("household_id").alias("hh_id"),
+        pl.col("tour_id"),
+        pl.col("tour_category"),
+        pl.col("primary_purpose").alias("tour_purpose"),
+        pl.col("composition").alias("tour_composition"),
+        pl.col("tour_participants"),
+        pl.col("origin").alias("orig_taz"),
+        pl.col("destination").alias("dest_taz"),
+        pl.col("start").alias("start_hour"),
+        pl.col("end").alias("end_hour"),
+        pl.col("tour_mode"),
+        pl.col("sample_rate").alias("sampleRate"),
+    )
+    joint_tour_data.write_csv(main / f"jointTourData_{iter_label}.csv")
+    log.info("  Wrote jointTourData_%s.csv (%d rows)", iter_label, len(joint_tour_data))
+
+    # -----------------------------------------------------------------
+    # Trip prep: join tour_category + sample_rate, derive fields
+    # -----------------------------------------------------------------
+    tour_keys = tours.select(
+        "tour_id",
+        "tour_category",
+        "tour_mode",
+        "primary_purpose",
+        "number_of_participants",
+        "sample_rate",
+    )
+
+    trip = trips.join(tour_keys, on="tour_id", how="left", suffix="_tour")
+
+    # orig_purpose: previous trip's purpose within the same tour,
+    # "Home" for first outbound, tour purpose for first inbound
+    trip = trip.sort("household_id", "person_id", "tour_id", "outbound", "trip_num")
+    trip = trip.with_columns(
+        pl.col("purpose").shift(1).over("tour_id", "outbound").alias("_prev_purpose")
+    )
+    trip = trip.with_columns(
+        pl.when(pl.col("_prev_purpose").is_not_null())
+        .then(pl.col("_prev_purpose"))
+        .when(pl.col("outbound"))
+        .then(pl.lit("Home"))
+        .otherwise(pl.col("primary_purpose"))
+        .alias("orig_purpose")
+    )
+
+    # inbound = 1 - outbound
+    trip = trip.with_columns(
+        pl.when(pl.col("outbound"))
+        .then(pl.lit(0))
+        .otherwise(pl.lit(1))
+        .cast(pl.Int32)
+        .alias("inbound")
+    )
+
+    # stop_id = trip_num - 1
+    trip = trip.with_columns((pl.col("trip_num") - 1).cast(pl.Int32).alias("stop_id"))
+
+    # person_num from per
+    per_num = per.select("person_id", "person_num")
+    trip = trip.join(per_num, on="person_id", how="left")
+
+    # -----------------------------------------------------------------
+    # Shared trip columns (individual)
+    # -----------------------------------------------------------------
+    trip_cols = [
+        pl.col("household_id").alias("hh_id"),
+        pl.col("person_id"),
+        pl.col("person_num"),
+        pl.col("tour_id"),
+        pl.col("stop_id"),
+        pl.col("inbound"),
+        pl.col("primary_purpose").alias("tour_purpose"),
+        pl.col("orig_purpose"),
+        pl.col("purpose").alias("dest_purpose"),
+        pl.col("origin").alias("orig_taz"),
+        pl.lit(0).cast(pl.Int32).alias("orig_walk_segment"),  # not modeled in ActivitySim
+        pl.col("destination").alias("dest_taz"),
+        pl.lit(0).cast(pl.Int32).alias("dest_walk_segment"),  # not modeled in ActivitySim
+        pl.col("depart").alias("depart_hour"),
+        pl.col("trip_mode"),
+        pl.col("tour_mode"),
+        pl.col("tour_category"),
+        pl.lit(0).cast(pl.Int32).alias("avAvailable"),  # AV not in scope
+        pl.col("sample_rate").alias("sampleRate"),
+        pl.lit(0.0).cast(pl.Float64).alias("taxiWait"),  # TNC not in scope
+        pl.lit(0.0).cast(pl.Float64).alias("singleTNCWait"),  # TNC not in scope
+        pl.lit(0.0).cast(pl.Float64).alias("sharedTNCWait"),  # TNC not in scope
+    ]
+
+    # -----------------------------------------------------------------
+    # indivTripData
+    # -----------------------------------------------------------------
+    indiv_trips = trip.filter(pl.col("tour_category") != "joint")
+    indiv_trip_data = indiv_trips.select(*trip_cols)
+    indiv_trip_data.write_csv(main / f"indivTripData_{iter_label}.csv")
+    log.info("  Wrote indivTripData_%s.csv (%d rows)", iter_label, len(indiv_trip_data))
+
+    # -----------------------------------------------------------------
+    # jointTripData — no person_id/person_num, add num_participants
+    # -----------------------------------------------------------------
+    joint_trips = trip.filter(pl.col("tour_category") == "joint")
+    joint_trip_data = joint_trips.select(
+        pl.col("household_id").alias("hh_id"),
+        pl.col("tour_id"),
+        pl.col("stop_id"),
+        pl.col("inbound"),
+        pl.col("primary_purpose").alias("tour_purpose"),
+        pl.col("orig_purpose"),
+        pl.col("purpose").alias("dest_purpose"),
+        pl.col("origin").alias("orig_taz"),
+        pl.lit(0).cast(pl.Int32).alias("orig_walk_segment"),  # not modeled in ActivitySim
+        pl.col("destination").alias("dest_taz"),
+        pl.lit(0).cast(pl.Int32).alias("dest_walk_segment"),  # not modeled in ActivitySim
+        pl.col("depart").alias("depart_hour"),
+        pl.col("trip_mode"),
+        pl.col("number_of_participants").alias("num_participants"),
+        pl.col("tour_mode"),
+        pl.col("tour_category"),
+        pl.lit(0).cast(pl.Int32).alias("avAvailable"),  # AV not in scope
+        pl.col("sample_rate").alias("sampleRate"),
+        pl.lit(0.0).cast(pl.Float64).alias("taxiWait"),  # TNC not in scope
+        pl.lit(0.0).cast(pl.Float64).alias("singleTNCWait"),  # TNC not in scope
+        pl.lit(0.0).cast(pl.Float64).alias("sharedTNCWait"),  # TNC not in scope
+    )
+    joint_trip_data.write_csv(main / f"jointTripData_{iter_label}.csv")
+    log.info("  Wrote jointTripData_%s.csv (%d rows)", iter_label, len(joint_trip_data))
+
+    # -----------------------------------------------------------------
+    # wsLocResults — workers only
+    # -----------------------------------------------------------------
+    workers = per.filter(pl.col("workplace_zone_id") > 0)
+    ws = workers.join(
+        hh.select("household_id", "income", "home_zone_id"),
+        on="household_id",
+        how="left",
+        suffix="_hh",
+    )
+    ws_data = ws.select(
+        pl.col("household_id").alias("HHID"),
+        pl.col("person_id").alias("PersonID"),
+        pl.col("person_num").alias("PersonNum"),
+        pl.col("home_zone_id").alias("HomeTAZ"),
+        pl.lit(0).cast(pl.Int32).alias("HomeSubZone"),  # TODO: derive from walkAccessBuffers
+        pl.col("income").alias("Income"),
+        pl.col("workplace_zone_id").alias("WorkLocation"),
+        pl.lit(0).cast(pl.Int32).alias("WorkSubZone"),  # TODO: derive from walkAccessBuffers
+    )
+    ws_data.write_csv(main / f"wsLocResults_{iter_label}.csv")
+    log.info("  Wrote wsLocResults_%s.csv (%d rows)", iter_label, len(ws_data))

--- a/uv.lock
+++ b/uv.lock
@@ -267,6 +267,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7b/6248dada39781db1ab3ebf08943080df0796098515a87f6f8696d14ec744/narwhals-2.25.0.tar.gz", hash = "sha256:62c036c810662bf7820b7737077176313bc59350eeeefb808510f388c743e4b2", size = 677076, upload-time = "2026-08-20T18:10:15.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl", hash = "sha256:1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f", size = 467373, upload-time = "2026-08-20T18:10:13.834Z" },
+]
+
+[[package]]
 name = "ndindex"
 version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -381,6 +390,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
     { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
     { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/07/795c79dbce40c39bece88e69d049babbd23ffa95b5d117f248db8ea03abb/plotly-6.9.0.tar.gz", hash = "sha256:967ad33e8c704fed051800d11d985eb206a9c795c14206b30a6f463ed9c67d0d", size = 6919903, upload-time = "2026-07-09T14:55:59.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/18/d8544811ab076f876c4892b3714f5b0dad335e1dc33aef826df431b8325d/plotly-6.9.0-py3-none-any.whl", hash = "sha256:36bebe2f1bb13884774fe61689c329071446f6ce4a8927fb1f0d6fb24f581236", size = 9909646, upload-time = "2026-07-09T14:55:55.421Z" },
 ]
 
 [[package]]
@@ -745,7 +767,10 @@ dependencies = [
     { name = "numpy" },
     { name = "openmatrix" },
     { name = "pandas" },
+    { name = "plotly" },
+    { name = "polars" },
     { name = "psutil" },
+    { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -762,7 +787,6 @@ legacy = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "polars" },
     { name = "pytest" },
     { name = "pytest-coverage" },
     { name = "ruff" },
@@ -775,7 +799,10 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26" },
     { name = "openmatrix", specifier = ">=0.3.5" },
     { name = "pandas", specifier = ">=2.0" },
+    { name = "plotly", specifier = ">=6.7.0" },
+    { name = "polars", specifier = ">=1.39.3" },
     { name = "psutil", specifier = ">=5.9" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31" },
@@ -787,7 +814,6 @@ provides-extras = ["legacy"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "polars", specifier = ">=1.39.3" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-coverage", specifier = ">=0.0" },
     { name = "ruff", specifier = ">=0.15.11" },


### PR DESCRIPTION
> **PR 3 of 6** - Travel Model One to Python migration.
>
> These are **sequential**, not independent: each PR builds on the one before it.
> Merge order is #103 -> #104 -> #105 -> #110 -> #108 -> #109.
> Nothing changes what runs in production: CT-RAMP + Cube remain the production
> stack until each later phase passes its own gate.
>
> | # | Phase | PR | Scope | Files |
> |---|---|---|---|---|
> | 1 | Runtime harness | #103 | `tm1` CLI, CT-RAMP headless, **Cube launcher**, flat + scenario-supplied steps | 32 |
> | 2 | Cube matrix I/O | #104 | `cubeio` - TPP / OMX, bit-exact tests | 32 |
> | 3 | Calibration reporting <- **this PR** | #105 | HTML survey-vs-model report | 37 |
> | 4 | **Model parity** | #110 | the rest of `RunModel.bat` - preprocess, post-processing, source from pristine `INPUT/` | draft |
> | 5 | ActivitySim swap-in | #108 | config corpus, scenarios, ActivitySim/Cube bridge | 230 |
> | 6 | Assignment backend | #109 | new assignment backend + parity validation | 29 |
>
> **Each PR moves exactly one piece.** Demand and assignment are the two moving
> parts; every phase changes one of them and holds the other fixed, so each phase can
> be validated against the one before it:
>
> | Phase | Demand | Assignment | What actually changes |
> |---|---|---|---|
> | 1-3 | CT-RAMP | Cube | orchestration, matrix I/O, reporting — no model change |
> | 4 | CT-RAMP | Cube | the non-residential models move to Python |
> | 5 | **ActivitySim** | Cube | the demand engine, and nothing else |
> | 6 | ActivitySim | **new engine (undecided)** | the assignment engine, and nothing else |
>
> The combination deliberately never built is CT-RAMP + the new assignment engine.
> Whichever engine is chosen exists to serve ActivitySim, and CT-RAMP and Cube retire
> together — which is what keeps this a diagonal rather than a grid, and why the
> demand/assignment seam needs one modern format plus one legacy adapter rather than
> every engine speaking to every other.
>
> **Which engine replaces Cube is not yet decided.** #109 evaluates a candidate and
> does not adopt it; Cube remains the assignment engine until one is chosen and
> validated. Nothing before #109 depends on that choice — the `backend:` key exists
> precisely so it stays a late decision.
>
> Phase 4 is new, and deliberately sits *before* the ActivitySim swap-in: until the
> harness reproduces the legacy run from pristine inputs, an ActivitySim-vs-CT-RAMP
> comparison made through it cannot separate a demand-model difference from a harness
> difference. #110 is open as a draft holding the scope; #108 rebases onto it
> before either merges.
>
> **This is deliberately not a like-for-like port.** Parts of the legacy pipeline
> bridge its toolchain rather than model anything. The clearest case: `.tpp` matrices
> could only be read by Cube, so data was exported to CSV and passed between Cube, R
> and batch. Given the tools available that was a sound design — but re-implementing
> it in Python would carry the cost forward without the constraint that motivated it.
>
> About **10 GB of every 53 GB run is derived or duplicated data**:
>
> | Artifact | Size | Why it exists | How it goes away |
> |---|---|---|---|
> | `database/*SkimsDatabase*.csv` | 4.4 GB | exports `.tpp` skims to CSV for R and Python | **#104** — read `.tpp` natively |
> | `updated_output/*.rdata` | 1.0 GB | R re-serialisation of data already in CSV | **#104** — no Cube→CSV→R hop |
> | `main/indivTripDataIncome_3.csv` | 1.6 GB | rewrites a 1.5 GB trip table to add one column | join at read time |
> | `extractor/` | 2.2 GB | a subset staged as a folder so it can be copied to `M:` | ship a manifest, or write direct |
> | `INPUT/` copied into working dirs | 0.6 GB | keeps pristine inputs by duplicating them | read in place |
>
> The first two — **5.4 GB per run, plus a Cube job and an entire toolchain hop** —
> are unlocked by the `.tpp` reader in **#104**. The rest are retired as phase 4 ports
> the steps around them. So parity means *equivalent results*, not an equivalent file
> layout. Detail: [Port the intent, not the mechanism](https://github.com/BayAreaMetro/travel-model-one/blob/phase-3-calibration-report/MIGRATION_NOTES.md#port-the-intent-not-the-mechanism).
>
> Phases 7 (legacy housekeeping), 8 (documentation) and 9 (network enhancements)
> are not yet scoped.
> Full plan: [`MIGRATION_NOTES.md`](https://github.com/BayAreaMetro/travel-model-one/blob/phase-3-calibration-report/MIGRATION_NOTES.md).

---
### Goal

Replace the legacy spreadsheet calibration workflow with a **reproducible HTML report**
comparing model output against survey targets — and make it engine-agnostic from day one,
so CT-RAMP and ActivitySim can be judged on identical terms in #108.

### What's here
Self-contained HTML report, per submodel: work/school location, auto ownership, daily activity pattern, non-work destination choice, tour mode choice, trip mode choice.

Wired in as the `calibration` step and enabled for `base_2023_ctramp`.

### Engine-agnostic by construction
Readers normalise CT-RAMP, ActivitySim and survey column names to one canonical schema on load (`io.py`), so the submodel and rendering code never branches on source format. CT-RAMP exercises that path today; ActivitySim reuses it unchanged in #108.

### First consumer of #104
Trip-length distributions need a distance skim, and it is read straight from Cube's binary `nonmotskm.tpp` via `cubeio` - no Cube install, no intermediate export.

### Testing
Full suite green. `read_skim()` verified end-to-end on a real `.tpp` (2.18M OD pairs).







