### PR TITLE
Phase 3: streamlining — legacy `.job`/`.py` replaced with native Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+# ... but the build-steps package is source, not a packaging artifact
+!src/tm1/steps/build/
 develop-eggs/
 dist/
 downloads/

--- a/docs/legacy_crosswalk.md
+++ b/docs/legacy_crosswalk.md
@@ -1,0 +1,137 @@
+# RunModel.bat → `tm1`: where everything went
+
+A crosswalk for reviewers who know the legacy batch pipeline. It is organized by the
+**legacy** structure — `RunModel.bat`'s own step numbers — so you can start from the thing
+you know and find where it lives now, or why it is gone. Every file the batch pipeline
+touches appears exactly once.
+
+Each item has one of five fates:
+
+| Fate | Meaning |
+|---|---|
+| **moved** | same code executes, new caller — Cube `.job` files and CT-RAMP Java run unmodified via the harness |
+| **rewritten** | same function, same output, new native code in `src/tm1/` — the legacy script/job is never invoked |
+| **absorbed** | the *function* is now a property of the harness itself (config, logging, CLI), not a step at all |
+| **eliminated** | the reason it existed no longer holds — nothing replaces it because nothing needs to |
+| **not wired / deferred** | deliberately not carried over (yet); the trigger that would revive it is named |
+
+The boundary rule behind every row: **legacy execution ends at the engine boundary.**
+Cube jobs and CT-RAMP Java are engines — they run as-is and retire whole. Everything
+between them (batch logic, Python wrangling, format shuffling) is glue, and glue is
+rewritten in harness idioms or eliminated.
+
+Legacy files stay in `model-files/` untouched — the old `.bat` path still works. This
+document describes what the **new runner** executes.
+
+---
+
+## RunModel.bat, step by step
+
+### Steps 1–2 · Set up (paths, cluster, directories, inputs)
+
+| Legacy | Fate | Now |
+|---|---|---|
+| `SetPath.bat` | **absorbed** | the `tm1` CLI + Python venv; no PATH mutation |
+| `pip_list.bat` → `pip_list.log` | **eliminated** | `uv.lock` is the environment record, versioned |
+| Cube Cluster start (held for whole run) | **absorbed** | `run_cube_job(cluster_nodes=…)` starts/stops per job that needs one |
+| `MODEL_YEAR` / `FUTURE` sliced from the *folder name* | **eliminated** | explicit `model_year:` / `future:` in scenario YAML — results no longer depend on how a directory is spelled |
+| directory creation | **absorbed** | each step creates what it writes |
+| input copying (13.3 GB of working dirs) | **moved + repointed** | `copy_inputs` step, sourced from pristine `INPUT/` (25 MB) — *this PR* |
+| `notify_slack.py` | **absorbed** | `src/tm1/slack.py` |
+
+### Step 3 · Pre-process
+
+| Legacy | Fate | Now |
+|---|---|---|
+| `RuntimeConfiguration.py` (805 ln) | **rewritten** | split in two: host IP / JPPF distribution / shadow pricing / popsyn paths / project dir were already native in `simulate_ctramp` (`patch_properties` + JPPF patching); the remainder — parse `INPUT/params.properties`, propagate auto/truck opcost, WFH factors, free parking into `.properties`, `hwyParam.block`, and UEC `.xls` (`costPerMile`) — becomes the native `configure_ctramp` step — *this PR* |
+| `updateUECsToUseTollDist.py` | **not wired** | NGF scenarios only; trigger: an NGF run |
+| `csvToDbf.py` (94 ln) | **rewritten** | ~20 lines inside `build_highway_networks` (tolls.csv → the `.dbf` Cube's HWYNET reads) — *this PR* |
+| `SetTolls.job` | **moved** | `build_highway_networks` step, via `run_cube_job` — *this PR* |
+| `SetHovXferPenalties.job` | **moved** | ditto (note: its output may be read by nothing — runs regardless under re-wire; flagged, not blocking) |
+| `CreateFiveHighwayNetworks.job` | **moved** | ditto — produces `hwy/avgload{P}.net`, the artifact runs currently inherit |
+| `HsrTripGeneration.job` | **rewritten** | `build_hsr_trips`: `cubeio` reads `tripsHsr{P}_{2040,2050}.tpp`, interpolates to `model_year`, writes — one Cube job deleted — *this PR* |
+
+### Step 4 · Non-motorized level of service
+
+| Legacy | Fate | Now |
+|---|---|---|
+| `CreateNonMotorizedNetwork.job` | **moved** | `build_nonmotorized_skims` step — *this PR* |
+| `NonMotorizedSkims.job` | **moved** | ditto — produces `skims/nonmotskm.tpp`, which the calibration report currently reads from a reference run; that dependency ends here |
+
+### Step 4.5 · Initial transit files
+
+| Legacy | Fate | Now |
+|---|---|---|
+| `transitDwellAccess.py` Simple mode (538 ln, needs NetworkWrangler) | **rewritten** | `build_transit_lines`: parse the ASCII `.lin`, demux by time period, apply simple dwell by mode → `trn/transitOriginal{P}.lin`. The NetworkWrangler dependency goes with it — *this PR* |
+| its `transitVehicleVolsOnLink{P}.dbf` output | **eliminated** | referenced only by the script that writes it; nothing consumes it |
+
+### Steps 5–9 · The iteration loop (`RunIteration.bat` × 4)
+
+The loop structure itself — `goto` logic, `ITER`/`SAMPLESHARE` env vars, the
+0.15/0.30/0.50 sample ramp — was **absorbed** by the runner's `iterate:` block in #103.
+Inside it:
+
+| Legacy | Fate | Now |
+|---|---|---|
+| Step 1 `HwySkims.job` + `Accessibility.job` | **moved** | `tm1.assignment.cube.ctramp.run_skims` |
+| Step 1 (iter 1 only) `FindNoAccessZones.job` → `unconnected_zones.csv` → `filterUnconnectedHouseholds.py` | **rewritten** | `filter_popsyn`, one native step *before* the loop (the `ITER==1` guard was preprocess parked inside the loop): `cubeio` reads the skim, unconnected zones computed in memory, popsyn filtered with pandas. A Cube job, a handoff file, and a script collapse into one function — *this PR* |
+| Step 2 CT-RAMP Java (JPPF cluster, matrix/household managers) | **moved** | `simulate_ctramp` step — runs the stock Java |
+| Step 2 `updateTelecommute_forEN7.py` | **not wired** | EN7 scenarios only (`EN7=ENABLED`); trigger: an EN7 run |
+| Step 3 non-residential models (9 jobs: Ix\*, Truck\*, air pax, HSR submode) | **moved** | `run_nonres` inside the `assignment` step — all nine stock jobs. These are *model components* (trucks and internal-external are full models; air pax and HSR process input tables) and are orthogonal to any future demand-engine swap |
+| Step 4 `PrepAssign.job` → `HwyAssign.job` | **moved** | `assignment` step; `PrepAssign` output verified against the declared `demand:` artifact |
+| Step 4 transit (`PrepHwyNet`, `BuildTransitNetworks`, `TransitAssign`, `TransitSkims`) | **moved** | `tm1.assignment.cube.transit.run_transit` |
+| Step 5 feedback (5 jobs: Rename, Average, CalculateSpeeds, TestConvergence, MergeNetworks) | **moved** | `run_highway_feedback` |
+
+### Step 11 · Skim databases
+
+| Legacy | Fate | Now |
+|---|---|---|
+| `SkimsDatabase.job` (4.4 GB CSV per run) | **eliminated** | existed only because nothing outside Cube could read `.tpp`; `cubeio` reads them directly |
+| `updated_output/*.rdata` (1.0 GB) | **eliminated** | R re-serialization of the CSVs above; no Cube→CSV→R hop remains |
+
+### Steps 12–17 · Post-processing
+
+| Legacy | Fate | Now |
+|---|---|---|
+| `RunPrepareEmfac.bat` ×2 | **deferred** | trigger: air-quality conformity demand — regulatory, likeliest early revival |
+| `RunLogsums.bat` | **deferred** | re-runs the entire CT-RAMP Java stack; establish whether that is avoidable before ever wiring it |
+| `RunCoreSummaries.bat` (4× R) | **deferred** | fundamental deliverable; toolchain (port vs shell-to-R) undecided |
+| `RunMetrics` / `RunScenarioMetrics` (`utilities/RTP`, 115 files) | **not wired** | analysis run *against* outputs, not part of producing them |
+| off-model calculation (2035/2050 only) | **not wired** | trigger: a horizon-year run |
+| `net2csv_avgload5period.job` | **not wired** | revive when a consumer needs the per-class link CSV |
+
+### Step 18 · Directory clean-up
+
+| Legacy | Fate | Now |
+|---|---|---|
+| `ExtractKeyFiles.bat` (2.2 GB staging) | **eliminated** | files staged so they could be copied again; ship a manifest if sharing is needed |
+
+---
+
+## Supporting directories
+
+| Legacy | Fate | Now |
+|---|---|---|
+| `scripts/block/*.block` (speed/capacity tables, params) | **moved** | still read by the Cube jobs, unmodified; `hwyParam.block` is now *written* by `configure_ctramp` from scenario params instead of by `RuntimeConfiguration.py` |
+| `scripts/assign`, `skims`, `feedback`, `nonres` `.job` files | **moved** | run unmodified via `run_cube_job` — see rows above |
+| `scripts/core_summaries/` | **deferred** | see Step 14 |
+| `scripts/emfac/` | **deferred** | see Step 12 |
+| `scripts/database/` | **eliminated** | see Step 11 |
+| `utilities/` (386 scripts: bespoke requests, calibration one-offs, fare studies, select-link) | **not wired** | ad-hoc analyses against model outputs; they keep working against outputs and are not model-parity work |
+
+---
+
+## What a reviewer should check
+
+1. **Completeness** — every `runtpp`/`python`/`Rscript`/`call` in `RunModel.bat` and
+   `RunIteration.bat` has a row here. If you find one that doesn't, that's a review
+   finding.
+2. **Rewrites are output-identical** — each *rewritten* row is verified against the
+   reference run: text-diff for `.properties`/`.block`/`.lin`/CSV, cell-diff via `cubeio`
+   for `.tpp`. The `.net` files (built by *moved* Cube jobs) are verified indirectly
+   through their derived link CSV and skims.
+3. **Eliminations name the dead constraint** — if you think the constraint still holds
+   (something does read `SkimsDatabase` CSVs that can't use `cubeio`), that's a review
+   finding.
+4. **Deferred items have triggers, not apologies** — if a trigger is already live (someone
+   needs EMFAC now), say so and it moves into scope.

--- a/projects/PBA50+_FBP/config.yaml
+++ b/projects/PBA50+_FBP/config.yaml
@@ -159,7 +159,7 @@ steps:
         to: "{run_dir}/CTRAMP/scripts/metrics"
 
       # 3. INPUT/ -> the working directories (RunModel.bat 172-178).  popsyn is absent
-      #    on purpose: filterUnconnectedHouseholds.py writes it.
+      #    on purpose: the filter_popsyn step writes it.
       hwy:
         from: "{run_dir}/INPUT/hwy"
         to: "{run_dir}/hwy"
@@ -294,20 +294,22 @@ steps:
           job: "CTRAMP/scripts/skims/Accessibility.job"
 
       # RunIteration.bat 49-57 parks these under `if %ITER%==1`; with the skims built above
-      # they are ordinary warm-start steps.  Once the households are filtered they stay
+      # they are an ordinary warm-start step.  Once the households are filtered they stay
       # filtered -- refiltering against a later round's skims would change the population
       # mid-run.
-      - find_no_access_zones:         # zones with no tolled-DA path -> unconnected_zones.csv
-          job: "CTRAMP/scripts/skims/FindNoAccessZones.job"
-          verify: ["skims/unconnected_zones.csv", "skims/unconnected_zones.dbf"]
-          # The dbf, not the csv: the job *echo*s the csv header before the MATRIX step
-          # that does the work, so a failed run leaves a csv behind.  Only MATRIX creates
-          # the dbf.
-          skip_if_exists: "skims/unconnected_zones.dbf"
-      - filter_unconnected_households:  # INPUT/popsyn -> popsyn/, dropping unreachable homes
-          command: "CTRAMP/scripts/preprocess/filterUnconnectedHouseholds.py"
-          args: ["popsyn"]
-          skip_if_exists: "popsyn/hhFile.2023_v12.csv"   # the versioned name INPUT ships
+      #
+      # Native replacement for FindNoAccessZones.job + filterUnconnectedHouseholds.py:
+      # scans the AM highway skim for zones with no drivable path (Cube writes 500000
+      # where none exists), drops households home-based there, and writes
+      # popsyn/hhFile.csv + personFile.csv -- the canonical names CT-RAMP's properties
+      # point at.  With zero unconnected zones (the healthy, expected case) the INPUT
+      # files are byte-copied through unchanged.
+      - filter_popsyn:
+          from: "{run_dir}/INPUT/popsyn"
+          to: "{run_dir}/popsyn"
+          skim: "{run_dir}/skims/HWYSKMAM.tpp"
+          max_internal_zone: 1454   # zones 1455+ are externals -- flagged but never filtered
+          verify: ["popsyn/hhFile.csv", "popsyn/personFile.csv"]
 
   # ── The feedback loop · three identical rounds (RunIteration.bat) ─────────────────────
   # One round = demand + assignment; demand responds to the skims the previous round

--- a/projects/PBA50+_FBP/config.yaml
+++ b/projects/PBA50+_FBP/config.yaml
@@ -199,8 +199,15 @@ steps:
   # taking hwy/freeflow.net to hwy/withTolls.net and hwy/avgload{EA..EV}.net.
   - build_highway_networks:
       run_dir: "{run_dir}"
-  - hsr_trip_generation:
-      job: "CTRAMP/scripts/preprocess/HsrTripGeneration.job"
+  # Replaces HsrTripGeneration.job with cubeio: reads the California HSR model's 2040
+  # and 2050 tables and interpolates.  All zero before the 2040 opening year (so, zero
+  # for 2023) or when HSR_Interregional_Disable is set in trnParam.block, which
+  # configure_ctramp writes.
+  - build_hsr_trips:
+      from: "{run_dir}/INPUT/nonres"
+      to: "{run_dir}/nonres"
+      model_year: "{env:MODEL_YEAR}"
+      trn_param: "{run_dir}/CTRAMP/scripts/block/trnParam.block"
 
   # Non-motorized level of service (RunModel.bat step 4).  Free-flow only, so unlike
   # every other skim these need no assignment first, and the feedback loop never
@@ -208,12 +215,14 @@ steps:
   # NonMotorizedSkims, producing skims/nonmotskm.tpp (DISTWALK/DISTBIKE/DIST).
   - build_nonmotorized_skims:
       run_dir: "{run_dir}"
-  - transit_dwell_access:
-      command: "CTRAMP/scripts/skims/transitDwellAccess.py"
-      # The argv the script receives, not a transliteration: RunModel.bat 146-147 set the
-      # complex-mode variables to a single space and cmd collapses those, so passing "" here
-      # would add arguments the script never saw and crash it on int("").
-      args: ["NORMAL", "NoExtraDelay", "Simple", "complexDwell", "complexAccess"]
+  # RunModel.bat step 4.5's transitDwellAccess.py Simple mode, native -- and without
+  # NetworkWrangler.  With COMPLEXMODES_DWELL/ACCESS empty (as RunModel.bat ships them)
+  # that pass leaves the line data untouched, so the five transitOriginal{PERIOD}.lin are
+  # copies of transitLines.lin and of each other.  See the module docstring before
+  # enabling the complex dwell modes.
+  - build_transit_lines:
+      from: "{run_dir}/trn/transitLines.lin"
+      to: "{run_dir}/trn"
 
   # ── Warm start · iteration 0 ──────────────────────────────────────────────────────────
   # RunModel.bat's `set ITER=0` pass: assign the staged demand once, so round 1 has

--- a/projects/PBA50+_FBP/config.yaml
+++ b/projects/PBA50+_FBP/config.yaml
@@ -206,7 +206,6 @@ steps:
   - build_hsr_trips:
       from: "{run_dir}/INPUT/nonres"
       to: "{run_dir}/nonres"
-      model_year: "{env:MODEL_YEAR}"
       trn_param: "{run_dir}/CTRAMP/scripts/block/trnParam.block"
 
   # Non-motorized level of service (RunModel.bat step 4).  Free-flow only, so unlike

--- a/projects/PBA50+_FBP/config.yaml
+++ b/projects/PBA50+_FBP/config.yaml
@@ -193,24 +193,21 @@ steps:
       # period.  Must not exceed hwy_assign's cluster_nodes, or it addresses processes
       # that were never started.
       intrastep_processes: 48
-  - csv_to_dbf:
-      command: "CTRAMP/scripts/preprocess/csvToDbf.py"
-      args: ["hwy/tolls.csv", "hwy/tolls.dbf"]
-  - set_tolls:
-      job: "CTRAMP/scripts/preprocess/SetTolls.job"
-  - set_hov_xfer_penalties:
-      job: "CTRAMP/scripts/preprocess/SetHovXferPenalties.job"
-  - create_five_highway_networks:
-      job: "CTRAMP/scripts/preprocess/CreateFiveHighwayNetworks.job"
+  # RunModel.bat step 3, at the engine boundary: tolls.csv -> tolls.dbf is native
+  # (replacing csvToDbf.py, and with it the dbfpy3 dependency), then the stock Cube
+  # jobs run as-is -- SetTolls -> SetHovXferPenalties -> CreateFiveHighwayNetworks,
+  # taking hwy/freeflow.net to hwy/withTolls.net and hwy/avgload{EA..EV}.net.
+  - build_highway_networks:
+      run_dir: "{run_dir}"
   - hsr_trip_generation:
       job: "CTRAMP/scripts/preprocess/HsrTripGeneration.job"
 
   # Non-motorized level of service (RunModel.bat step 4).  Free-flow only, so unlike
-  # every other skim these need no assignment first.
-  - create_nonmotorized_network:
-      job: "CTRAMP/scripts/skims/CreateNonMotorizedNetwork.job"
-  - nonmotorized_skims:
-      job: "CTRAMP/scripts/skims/NonMotorizedSkims.job"
+  # every other skim these need no assignment first, and the feedback loop never
+  # touches them.  Stock Cube jobs as-is: CreateNonMotorizedNetwork ->
+  # NonMotorizedSkims, producing skims/nonmotskm.tpp (DISTWALK/DISTBIKE/DIST).
+  - build_nonmotorized_skims:
+      run_dir: "{run_dir}"
   - transit_dwell_access:
       command: "CTRAMP/scripts/skims/transitDwellAccess.py"
       # The argv the script receives, not a transliteration: RunModel.bat 146-147 set the

--- a/projects/ctramp_2023/config.yaml
+++ b/projects/ctramp_2023/config.yaml
@@ -194,8 +194,15 @@ steps:
   # taking hwy/freeflow.net to hwy/withTolls.net and hwy/avgload{EA..EV}.net.
   - build_highway_networks:
       run_dir: "{run_dir}"
-  - hsr_trip_generation:
-      job: "CTRAMP/scripts/preprocess/HsrTripGeneration.job"
+  # Replaces HsrTripGeneration.job with cubeio: reads the California HSR model's 2040
+  # and 2050 tables and interpolates.  All zero before the 2040 opening year (so, zero
+  # for 2023) or when HSR_Interregional_Disable is set in trnParam.block, which
+  # configure_ctramp writes.
+  - build_hsr_trips:
+      from: "{run_dir}/INPUT/nonres"
+      to: "{run_dir}/nonres"
+      model_year: "{env:MODEL_YEAR}"
+      trn_param: "{run_dir}/CTRAMP/scripts/block/trnParam.block"
 
   # Non-motorized level of service (RunModel.bat step 4).  Free-flow only, so unlike
   # every other skim these need no assignment first, and the feedback loop never
@@ -203,12 +210,14 @@ steps:
   # NonMotorizedSkims, producing skims/nonmotskm.tpp (DISTWALK/DISTBIKE/DIST).
   - build_nonmotorized_skims:
       run_dir: "{run_dir}"
-  - transit_dwell_access:
-      command: "CTRAMP/scripts/skims/transitDwellAccess.py"
-      # The argv the script receives, not a transliteration: RunModel.bat 146-147 set the
-      # complex-mode variables to a single space and cmd collapses those, so passing "" here
-      # would add arguments the script never saw and crash it on int("").
-      args: ["NORMAL", "NoExtraDelay", "Simple", "complexDwell", "complexAccess"]
+  # RunModel.bat step 4.5's transitDwellAccess.py Simple mode, native -- and without
+  # NetworkWrangler.  With COMPLEXMODES_DWELL/ACCESS empty (as RunModel.bat ships them)
+  # that pass leaves the line data untouched, so the five transitOriginal{PERIOD}.lin are
+  # copies of transitLines.lin and of each other.  See the module docstring before
+  # enabling the complex dwell modes.
+  - build_transit_lines:
+      from: "{run_dir}/trn/transitLines.lin"
+      to: "{run_dir}/trn"
 
   # ── Warm start · iteration 0 ──────────────────────────────────────────────────────────
   # RunModel.bat's `set ITER=0` pass: assign the staged demand once, so round 1 has

--- a/projects/ctramp_2023/config.yaml
+++ b/projects/ctramp_2023/config.yaml
@@ -154,7 +154,7 @@ steps:
         to: "{run_dir}/CTRAMP/scripts/metrics"
 
       # 3. INPUT/ -> the working directories (RunModel.bat 172-178).  popsyn is absent
-      #    on purpose: filterUnconnectedHouseholds.py writes it.
+      #    on purpose: the filter_popsyn step writes it.
       hwy:
         from: "{run_dir}/INPUT/hwy"
         to: "{run_dir}/hwy"
@@ -289,20 +289,22 @@ steps:
           job: "CTRAMP/scripts/skims/Accessibility.job"
 
       # RunIteration.bat 49-57 parks these under `if %ITER%==1`; with the skims built above
-      # they are ordinary warm-start steps.  Once the households are filtered they stay
+      # they are an ordinary warm-start step.  Once the households are filtered they stay
       # filtered -- refiltering against a later round's skims would change the population
       # mid-run.
-      - find_no_access_zones:         # zones with no tolled-DA path -> unconnected_zones.csv
-          job: "CTRAMP/scripts/skims/FindNoAccessZones.job"
-          verify: ["skims/unconnected_zones.csv", "skims/unconnected_zones.dbf"]
-          # The dbf, not the csv: the job *echo*s the csv header before the MATRIX step
-          # that does the work, so a failed run leaves a csv behind.  Only MATRIX creates
-          # the dbf.
-          skip_if_exists: "skims/unconnected_zones.dbf"
-      - filter_unconnected_households:  # INPUT/popsyn -> popsyn/, dropping unreachable homes
-          command: "CTRAMP/scripts/preprocess/filterUnconnectedHouseholds.py"
-          args: ["popsyn"]
-          skip_if_exists: "popsyn/hhFile.2023_v12.csv"   # the versioned name INPUT ships
+      #
+      # Native replacement for FindNoAccessZones.job + filterUnconnectedHouseholds.py:
+      # scans the AM highway skim for zones with no drivable path (Cube writes 500000
+      # where none exists), drops households home-based there, and writes
+      # popsyn/hhFile.csv + personFile.csv -- the canonical names CT-RAMP's properties
+      # point at.  With zero unconnected zones (the healthy, expected case) the INPUT
+      # files are byte-copied through unchanged.
+      - filter_popsyn:
+          from: "{run_dir}/INPUT/popsyn"
+          to: "{run_dir}/popsyn"
+          skim: "{run_dir}/skims/HWYSKMAM.tpp"
+          max_internal_zone: 1454   # zones 1455+ are externals -- flagged but never filtered
+          verify: ["popsyn/hhFile.csv", "popsyn/personFile.csv"]
 
   # ── The feedback loop · three identical rounds (RunIteration.bat) ─────────────────────
   # One round = demand + assignment; demand responds to the skims the previous round

--- a/projects/ctramp_2023/config.yaml
+++ b/projects/ctramp_2023/config.yaml
@@ -188,24 +188,21 @@ steps:
       # period.  Must not exceed hwy_assign's cluster_nodes, or it addresses processes
       # that were never started.
       intrastep_processes: 48
-  - csv_to_dbf:
-      command: "CTRAMP/scripts/preprocess/csvToDbf.py"
-      args: ["hwy/tolls.csv", "hwy/tolls.dbf"]
-  - set_tolls:
-      job: "CTRAMP/scripts/preprocess/SetTolls.job"
-  - set_hov_xfer_penalties:
-      job: "CTRAMP/scripts/preprocess/SetHovXferPenalties.job"
-  - create_five_highway_networks:
-      job: "CTRAMP/scripts/preprocess/CreateFiveHighwayNetworks.job"
+  # RunModel.bat step 3, at the engine boundary: tolls.csv -> tolls.dbf is native
+  # (replacing csvToDbf.py, and with it the dbfpy3 dependency), then the stock Cube
+  # jobs run as-is -- SetTolls -> SetHovXferPenalties -> CreateFiveHighwayNetworks,
+  # taking hwy/freeflow.net to hwy/withTolls.net and hwy/avgload{EA..EV}.net.
+  - build_highway_networks:
+      run_dir: "{run_dir}"
   - hsr_trip_generation:
       job: "CTRAMP/scripts/preprocess/HsrTripGeneration.job"
 
   # Non-motorized level of service (RunModel.bat step 4).  Free-flow only, so unlike
-  # every other skim these need no assignment first.
-  - create_nonmotorized_network:
-      job: "CTRAMP/scripts/skims/CreateNonMotorizedNetwork.job"
-  - nonmotorized_skims:
-      job: "CTRAMP/scripts/skims/NonMotorizedSkims.job"
+  # every other skim these need no assignment first, and the feedback loop never
+  # touches them.  Stock Cube jobs as-is: CreateNonMotorizedNetwork ->
+  # NonMotorizedSkims, producing skims/nonmotskm.tpp (DISTWALK/DISTBIKE/DIST).
+  - build_nonmotorized_skims:
+      run_dir: "{run_dir}"
   - transit_dwell_access:
       command: "CTRAMP/scripts/skims/transitDwellAccess.py"
       # The argv the script receives, not a transliteration: RunModel.bat 146-147 set the

--- a/projects/ctramp_2023/config.yaml
+++ b/projects/ctramp_2023/config.yaml
@@ -201,7 +201,6 @@ steps:
   - build_hsr_trips:
       from: "{run_dir}/INPUT/nonres"
       to: "{run_dir}/nonres"
-      model_year: "{env:MODEL_YEAR}"
       trn_param: "{run_dir}/CTRAMP/scripts/block/trnParam.block"
 
   # Non-motorized level of service (RunModel.bat step 4).  Free-flow only, so unlike

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,18 +14,11 @@ dependencies = [
     "requests>=2.31",
     # tm1.steps.configure_ctramp._patch_workbook (native, always runs) reads/writes the
     # UEC workbooks in place, which are still binary .xls -- a format neither openpyxl
-    # nor pandas can write.  Not optional: every run reaches this step.
+    # nor pandas can write.  Not optional: every run reaches this step, and it goes
+    # when the workbooks stop being .xls -- the ActivitySim swap, not this phase.
     "xlrd>=2.0",
     "xlutils>=2.0",
     "xlwt>=1.3",
-    # dbfpy3 (csvToDbf.py) and NetworkWrangler (transitDwellAccess.py) back `command:`
-    # steps that every project's pipeline runs unconditionally today -- csvToDbf.py
-    # writes hwy/tolls.dbf, which the Cube LOOKUPI in HwyAssign.job reads.  Phase 4
-    # replaces those scripts with native steps and deletes both dependencies outright;
-    # until then they are load-bearing, not optional, so they live here rather than in
-    # a `legacy` extra someone has to remember to ask for.
-    "dbfpy3>=2.3",
-    "NetworkWrangler @ git+https://github.com/BayAreaMetro/NetworkWrangler@c806951496126c6c5a3a37f5c325176aee91f31d",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,25 +15,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# What the legacy RunModel.bat scripts need, and nothing else does.  Every entry
-# exists to run one `command:` step in the CT-RAMP project:
+# What the legacy CT-RAMP files still need, and nothing else does:
 #
-#   dbfpy3           csvToDbf.py            hwy/tolls.csv -> the .dbf Cube's LOOKUPI reads
-#   NetworkWrangler  transitDwellAccess.py  `from Wrangler import ...`; pulls simpleparse,
-#                                           xlrd, numpy, pandas and pywin32 itself
-#   xlrd/xlwt/       RuntimeConfiguration.py  patches costPerMile into the UEC .xls files
-#     xlutils
+#   xlrd/xlwt/   the UEC .xls workbooks -- configure_ctramp patches costPerMile into
+#     xlutils    them in place, which means reading and rewriting the .xls format
 #
-# NetworkWrangler is pinned to a commit, not a branch, so `uv sync` on another machine
-# resolves to the same code.  c806951 is the commit that made it installable at all --
-# before it, setup.py omitted the _static/ directory that Wrangler imports at module
-# level, so only `pip install -e` off a clone ever worked.
+# `dbfpy3` and `NetworkWrangler` left with this phase: build_highway_networks writes
+# tolls.dbf natively (was csvToDbf.py) and build_transit_lines demuxes the .lin files
+# natively (was transitDwellAccess.py, the only thing that ever imported Wrangler).
 #
-# Phase 4 replaces those scripts with native steps, and this whole extra goes with
-# them -- it is complete when no `command:` in any project points into CTRAMP/scripts.
+# This extra empties out when the UEC workbooks stop being .xls -- which is the
+# ActivitySim swap, not this phase.
 legacy = [
-    "dbfpy3>=2.3",
-    "NetworkWrangler @ git+https://github.com/BayAreaMetro/NetworkWrangler@c806951496126c6c5a3a37f5c325176aee91f31d",
     "xlrd>=2.0",
     "xlutils>=2.0",
     "xlwt>=1.3",

--- a/src/cube/job.py
+++ b/src/cube/job.py
@@ -329,54 +329,21 @@ def _run_via_schtasks(  # noqa: C901
     return int(sentinel.read_text().strip() or "1"), logfile
 
 
-def run_cube_job(
-    job: str | Path,
-    cwd: str | Path,
+def _execute_job(
+    job: Path,
+    cwd: Path,
+    logfile: Path,
     *,
-    env_extra: dict[str, object] | None = None,
-    timeout: float = 7200,
-    cluster_nodes: int | None = None,
-    commpath: str | Path | None = None,
-) -> int:
-    """Run a Cube Voyager ``.job`` and return its exit code (raises on non-zero).
+    env_extra: dict[str, object] | None,
+    timeout: float,
+    cluster_nodes: int | None,
+    cpath: Path | None,
+) -> tuple[int, str, Path]:
+    """Run the job, returning ``(exit code, log text, log file)``.
 
-    Parameters
-    ----------
-    job
-        Path to the ``.job`` script.
-    cwd
-        Working directory for the run (job-relative input/output paths resolve
-        against this).
-    env_extra
-        Extra environment variables to set before running (e.g. iteration
-        parameters ``ITER``/``WGT`` for assignment/feedback jobs).
-    timeout
-        Seconds to wait for completion (schtasks path).
-    cluster_nodes
-        If set, start a local Cube Cluster of this many nodes around the job
-        (required by jobs using ``DistributeMultistep``/``Wait4Files`` — i.e. the
-        assignment, skim and feedback jobs).  Must be >= the highest ``processNum``
-        the job distributes (5 for the period-looped jobs).
-    commpath
-        Cluster communication directory (defaults to ``<cwd>/commpath``).  The job's
-        ``%COMMPATH%`` token resolves to this.
+    Split out of :func:`run_cube_job` so cancellation has one place to catch:
+    everything that can leave a cluster node running happens inside here.
     """
-    job = Path(job).resolve()
-    cwd = Path(cwd).resolve()
-    if not job.exists():
-        msg = f"Cube job not found: {job}"
-        raise FileNotFoundError(msg)
-    cwd.mkdir(parents=True, exist_ok=True)
-
-    # Bound up front so every path below -- and the messages after them -- can name
-    # the log.  The schtasks path replaces it with its own per-run name.
-    logfile = cwd / f"_cube_{job.stem}.log"
-
-    cpath: Path | None = None
-    if cluster_nodes:
-        cpath = Path(commpath).resolve() if commpath else cwd / "commpath"
-        cpath.mkdir(parents=True, exist_ok=True)
-
     if is_interactive_session():
         env = os.environ.copy()
         env["PATH"] = _CUBE_PATH + ";" + env.get("PATH", "")
@@ -426,6 +393,71 @@ def run_cube_job(
                 cluster_nodes=cluster_nodes, commpath=cpath,
             )
         log_text = logfile.read_text(errors="replace") if logfile.exists() else ""
+    return rc, log_text, logfile
+
+
+def run_cube_job(
+    job: str | Path,
+    cwd: str | Path,
+    *,
+    env_extra: dict[str, object] | None = None,
+    timeout: float = 7200,
+    cluster_nodes: int | None = None,
+    commpath: str | Path | None = None,
+) -> int:
+    """Run a Cube Voyager ``.job`` and return its exit code (raises on non-zero).
+
+    Parameters
+    ----------
+    job
+        Path to the ``.job`` script.
+    cwd
+        Working directory for the run (job-relative input/output paths resolve
+        against this).
+    env_extra
+        Extra environment variables to set before running (e.g. iteration
+        parameters ``ITER``/``WGT`` for assignment/feedback jobs).
+    timeout
+        Seconds to wait for completion (schtasks path).
+    cluster_nodes
+        If set, start a local Cube Cluster of this many nodes around the job
+        (required by jobs using ``DistributeMultistep``/``Wait4Files`` — i.e. the
+        assignment, skim and feedback jobs).  Must be >= the highest ``processNum``
+        the job distributes (5 for the period-looped jobs).
+    commpath
+        Cluster communication directory (defaults to ``<cwd>/commpath``).  The job's
+        ``%COMMPATH%`` token resolves to this.
+    """
+    job = Path(job).resolve()
+    cwd = Path(cwd).resolve()
+    if not job.exists():
+        msg = f"Cube job not found: {job}"
+        raise FileNotFoundError(msg)
+    cwd.mkdir(parents=True, exist_ok=True)
+
+    # Bound up front so every path below -- and the messages after them -- can name
+    # the log.  The schtasks path replaces it with its own per-run name.
+    logfile = cwd / f"_cube_{job.stem}.log"
+
+    cpath: Path | None = None
+    if cluster_nodes:
+        cpath = Path(commpath).resolve() if commpath else cwd / "commpath"
+        cpath.mkdir(parents=True, exist_ok=True)
+
+    try:
+        rc, log_text, logfile = _execute_job(
+            job, cwd, logfile,
+            env_extra=env_extra, timeout=timeout,
+            cluster_nodes=cluster_nodes, cpath=cpath,
+        )
+    except KeyboardInterrupt:
+        # Ctrl-C reaches this process, but the cluster nodes were started by cmd or
+        # by the scheduled task and never see the signal: without this they keep
+        # running and holding license leases (a 48-node job leaves 49 orphans).
+        # The bat file's `Cluster ... Close Exit` line never runs either.
+        log.warning("Cancelled during Cube job %s -- clearing cluster", job.name)
+        recover_license()
+        raise
 
     # A startup access-violation (0xC0000005 / -1073741819) means runtpp could not
     # reach the Bentley license pipe — a broken license entitlement, not a stuck

--- a/src/tm1/steps/__init__.py
+++ b/src/tm1/steps/__init__.py
@@ -28,7 +28,9 @@ import tm1.steps.assignment as assignment_step
 import tm1.steps.configure_ctramp as configure_ctramp_step
 import tm1.steps.external as external_step
 import tm1.steps.setup as setup_step
+import tm1.steps.build.hsr_trips as build_hsr_trips_step
 import tm1.steps.build.highway_networks as build_highway_networks_step
+import tm1.steps.build.transit_lines as build_transit_lines_step
 import tm1.steps.build.nonmotorized_skims as build_nonmotorized_skims_step
 import tm1.steps.filter_popsyn as filter_popsyn_step
 import tm1.steps.simulate_ctramp as simulate_ctramp_step
@@ -52,6 +54,8 @@ STEPS: dict[str, Callable] = {
     "copy_inputs": setup_step.run,
     "build_highway_networks": build_highway_networks_step.run,
     "build_nonmotorized_skims": build_nonmotorized_skims_step.run,
+    "build_transit_lines": build_transit_lines_step.run,
+    "build_hsr_trips": build_hsr_trips_step.run,
     "filter_popsyn": filter_popsyn_step.run,
     "configure_ctramp": configure_ctramp_step.run,
     "simulate_ctramp": simulate_ctramp_step.run,

--- a/src/tm1/steps/__init__.py
+++ b/src/tm1/steps/__init__.py
@@ -28,6 +28,8 @@ import tm1.steps.assignment as assignment_step
 import tm1.steps.configure_ctramp as configure_ctramp_step
 import tm1.steps.external as external_step
 import tm1.steps.setup as setup_step
+import tm1.steps.build.highway_networks as build_highway_networks_step
+import tm1.steps.build.nonmotorized_skims as build_nonmotorized_skims_step
 import tm1.steps.filter_popsyn as filter_popsyn_step
 import tm1.steps.simulate_ctramp as simulate_ctramp_step
 import tm1.steps.staging as staging_step
@@ -48,6 +50,8 @@ STEPS: dict[str, Callable] = {
     "publish_networks": staging_step.publish_networks,
     # The model itself.
     "copy_inputs": setup_step.run,
+    "build_highway_networks": build_highway_networks_step.run,
+    "build_nonmotorized_skims": build_nonmotorized_skims_step.run,
     "filter_popsyn": filter_popsyn_step.run,
     "configure_ctramp": configure_ctramp_step.run,
     "simulate_ctramp": simulate_ctramp_step.run,

--- a/src/tm1/steps/__init__.py
+++ b/src/tm1/steps/__init__.py
@@ -25,14 +25,14 @@ from pathlib import Path
 from types import ModuleType
 
 import tm1.steps.assignment as assignment_step
+import tm1.steps.build.highway_networks as build_highway_networks_step
+import tm1.steps.build.hsr_trips as build_hsr_trips_step
+import tm1.steps.build.nonmotorized_skims as build_nonmotorized_skims_step
+import tm1.steps.build.transit_lines as build_transit_lines_step
 import tm1.steps.configure_ctramp as configure_ctramp_step
 import tm1.steps.external as external_step
-import tm1.steps.setup as setup_step
-import tm1.steps.build.hsr_trips as build_hsr_trips_step
-import tm1.steps.build.highway_networks as build_highway_networks_step
-import tm1.steps.build.transit_lines as build_transit_lines_step
-import tm1.steps.build.nonmotorized_skims as build_nonmotorized_skims_step
 import tm1.steps.filter_popsyn as filter_popsyn_step
+import tm1.steps.setup as setup_step
 import tm1.steps.simulate_ctramp as simulate_ctramp_step
 import tm1.steps.staging as staging_step
 

--- a/src/tm1/steps/__init__.py
+++ b/src/tm1/steps/__init__.py
@@ -28,6 +28,7 @@ import tm1.steps.assignment as assignment_step
 import tm1.steps.configure_ctramp as configure_ctramp_step
 import tm1.steps.external as external_step
 import tm1.steps.setup as setup_step
+import tm1.steps.filter_popsyn as filter_popsyn_step
 import tm1.steps.simulate_ctramp as simulate_ctramp_step
 import tm1.steps.staging as staging_step
 
@@ -47,6 +48,7 @@ STEPS: dict[str, Callable] = {
     "publish_networks": staging_step.publish_networks,
     # The model itself.
     "copy_inputs": setup_step.run,
+    "filter_popsyn": filter_popsyn_step.run,
     "configure_ctramp": configure_ctramp_step.run,
     "simulate_ctramp": simulate_ctramp_step.run,
     "assignment": assignment_step.run,

--- a/src/tm1/steps/build/__init__.py
+++ b/src/tm1/steps/build/__init__.py
@@ -11,4 +11,29 @@ when the engine goes.
   then SetTolls/SetHovXferPenalties/CreateFiveHighwayNetworks as-is.
 - :mod:`~tm1.steps.build.nonmotorized_skims` — CreateNonMotorizedNetwork +
   NonMotorizedSkims as-is -> ``skims/nonmotskm.tpp``.
+- :mod:`~tm1.steps.build.transit_lines` — per-period ``transitOriginal{P}.lin``,
+  replacing transitDwellAccess.py's Simple mode (and its NetworkWrangler dependency).
+- :mod:`~tm1.steps.build.hsr_trips` — high-speed-rail trip tables interpolated to
+  the model year, replacing HsrTripGeneration.job.
 """
+
+from pathlib import Path
+
+
+def resolve_path(
+    step_cfg: dict, cfg: dict, key: str, *default_parts: str
+) -> Path:
+    """A step's path setting, falling back to ``run_dir`` plus *default_parts*.
+
+    ``run_dir`` is consulted only when *key* is absent, so a step whose paths
+    are all given explicitly needs no project directory at all -- which is what
+    makes these steps testable against a scratch directory.
+    """
+    explicit = step_cfg.get(key)
+    if explicit:
+        return Path(explicit)
+    run_dir = step_cfg.get("run_dir") or cfg.get("run_dir")
+    if not run_dir:
+        msg = f"set `{key}`, or `run_dir` to derive it from"
+        raise KeyError(msg)
+    return Path(run_dir, *default_parts)

--- a/src/tm1/steps/build/__init__.py
+++ b/src/tm1/steps/build/__init__.py
@@ -1,0 +1,14 @@
+"""Build-once input staging: pristine ``INPUT/`` files -> model-loop inputs.
+
+Every step in this package runs after ``copy_inputs`` and before ``iterate:``,
+building an artifact the loop consumes but never rewrites.  They are grouped
+here because they share a fate as well as a position: each wraps Cube-era
+tooling behind a step whose *artifact* outlives Cube — see the retirement
+warning in each module's docstring for what to delete versus re-implement
+when the engine goes.
+
+- :mod:`~tm1.steps.build.highway_networks` — tolls.csv -> tolls.dbf (native),
+  then SetTolls/SetHovXferPenalties/CreateFiveHighwayNetworks as-is.
+- :mod:`~tm1.steps.build.nonmotorized_skims` — CreateNonMotorizedNetwork +
+  NonMotorizedSkims as-is -> ``skims/nonmotskm.tpp``.
+"""

--- a/src/tm1/steps/build/highway_networks.py
+++ b/src/tm1/steps/build/highway_networks.py
@@ -1,0 +1,186 @@
+"""Build the tolled and time-of-day highway networks (RunModel.bat step 3).
+
+The stock Cube jobs run as-is; the one piece of legacy glue between them is
+rewritten natively:
+
+- ``csvToDbf.py`` -> :func:`_write_dbf` — ``hwy/tolls.csv`` to the
+  ``hwy/tolls.dbf`` that ``SetTolls.job``'s ``LOOKUPI`` reads (Cube's lookup
+  cannot read csv).  Same column-type inference ladder as the legacy script:
+  try int, fall back to float, fall back to string.
+- ``SetTolls.job``                  ``hwy/freeflow.net`` -> ``hwy/withTolls.net``
+- ``SetHovXferPenalties.job``       ``hwy/withTolls.net`` -> ``hwy/withHovXferPenalties.net``
+- ``CreateFiveHighwayNetworks.job`` ``hwy/withTolls.net`` -> ``hwy/avgload{EA..EV}.net``
+
+None of the jobs distributes, so no Cube cluster is started.
+
+``withHovXferPenalties.net`` is consumed by nothing downstream —
+``CreateFiveHighwayNetworks`` reads ``withTolls.net`` — but the job still runs
+so the sequence stays exactly ``RunModel.bat``'s.
+
+Config::
+
+    build_highway_networks:
+      run_dir: "{run_dir}"
+
+.. warning:: CUBE-ERA IMPLEMENTATION — DELETE WITH CUBE, KEEP THE STEP'S JOB.
+
+    The *function* is permanent: every assignment engine needs tolled,
+    time-of-day networks built from ``INPUT/hwy``.  The *implementation* is
+    not: the three ``.job`` scripts and the ``.net`` files they produce mean
+    nothing to a non-Cube engine (the AequilibraE lineage already builds its
+    networks natively — see ``build_aeq_inputs``).  When Cube is retired,
+    replace this module's body wholesale rather than porting any of it, and
+    delete the DBF writer below with it: ``tolls.dbf`` exists only because
+    Cube's ``LOOKUPI`` cannot read csv.  Do not promote the DBF writer to a
+    shared utility.
+"""
+
+import csv
+import logging
+import struct
+from datetime import datetime
+from pathlib import Path
+
+from cube.job import run_cube_job
+from tm1.project.config import step_config
+
+log = logging.getLogger(__name__)
+
+PERIODS: tuple[str, ...] = ("EA", "AM", "MD", "PM", "EV")
+
+_JOBS: tuple[str, ...] = (
+    "SetTolls.job",
+    "SetHovXferPenalties.job",
+    "CreateFiveHighwayNetworks.job",
+)
+
+_OUTPUTS: tuple[str, ...] = (
+    "withTolls.net",
+    "withHovXferPenalties.net",
+    *(f"avgload{p}.net" for p in PERIODS),
+)
+
+# DBF field widths, as csvToDbf.py chose them: numerics are 10 wide (5 decimal
+# places when float); strings are sized to the longest value plus two.
+_NUM_WIDTH = 10
+_NUM_DECIMALS = 5
+_DBF_NAME_LEN = 10
+
+
+def _infer_fields(header: list[str], rows: list[list[str]]) -> list[tuple[str, str, int, int]]:
+    """Per-column DBF specs ``(name, type, length, decimals)`` from the csv values.
+
+    Follows csvToDbf.py's ladder — a column is int until a value fails ``int()``,
+    then float until one fails ``float()``, then character — so the fields come
+    out identical to what the legacy conversion produced.
+    """
+    fields: list[tuple[str, str, int, int]] = []
+    seen: set[str] = set()
+    for idx, col in enumerate(header):
+        name = col[:_DBF_NAME_LEN].upper()
+        if name in seen:
+            msg = f"Column {col!r} collides with another at DBF name {name!r}"
+            raise ValueError(msg)
+        seen.add(name)
+
+        values = [row[idx] for row in rows]
+        try:
+            for v in values:
+                int(v)
+            fields.append((name, "N", _NUM_WIDTH, 0))
+            continue
+        except ValueError:
+            pass
+        try:
+            for v in values:
+                float(v)
+            fields.append((name, "N", _NUM_WIDTH, _NUM_DECIMALS))
+        except ValueError:
+            fields.append((name, "C", max(len(v) for v in values) + 2, 0))
+    return fields
+
+
+def _format_value(value: str, ftype: str, length: int, decimals: int) -> bytes:
+    """One csv value as its fixed-width DBF record bytes."""
+    if ftype == "N":
+        text = str(int(value)) if decimals == 0 else f"{float(value):.{decimals}f}"
+        out = text.rjust(length)
+    else:
+        out = value.ljust(length)
+    if len(out) > length:
+        msg = f"Value {value!r} does not fit DBF field width {length}"
+        raise ValueError(msg)
+    return out.encode("ascii")
+
+
+def _write_dbf(csv_path: Path, dbf_path: Path) -> int:
+    """Convert a csv to a dBASE III file (native csvToDbf.py). Returns row count."""
+    with csv_path.open(newline="") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        rows = list(reader)
+
+    fields = _infer_fields(header, rows)
+    record_size = 1 + sum(length for _, _, length, _ in fields)
+    header_size = 32 + 32 * len(fields) + 1
+    today = datetime.now().astimezone()
+
+    with dbf_path.open("wb") as out:
+        out.write(
+            struct.pack(
+                "<4BIHH20x",
+                0x03, today.year - 1900, today.month, today.day,
+                len(rows), header_size, record_size,
+            )
+        )
+        offset = 1  # running record offset, as the legacy writer recorded it
+        for name, ftype, length, decimals in fields:
+            out.write(
+                struct.pack(
+                    "<11scI2B14x",
+                    name.encode("ascii"), ftype.encode("ascii"),
+                    offset, length, decimals,
+                )
+            )
+            offset += length
+        out.write(b"\x0d")
+        for row in rows:
+            out.write(b" ")
+            for value, spec in zip(row, fields, strict=True):
+                out.write(_format_value(value, spec[1], spec[2], spec[3]))
+        out.write(b"\x1a")
+
+    log.info("Wrote %s: %d records, %d fields", dbf_path, len(rows), len(fields))
+    return len(rows)
+
+
+def run(
+    config_dir: Path,  # noqa: ARG001
+    cfg: dict,
+    **kwargs: object,
+) -> str | None:
+    """tolls.csv -> tolls.dbf, then the three stock network-building Cube jobs."""
+    step_cfg = step_config(cfg, "build_highway_networks", kwargs)
+    run_dir = Path(step_cfg.get("run_dir") or cfg["run_dir"])
+    hwy = run_dir / "hwy"
+
+    if not kwargs.get("force", False) and all((hwy / n).exists() for n in _OUTPUTS):
+        log.info("Highway networks already built in %s", hwy)
+        return "skipped"
+
+    for needed in (hwy / "freeflow.net", hwy / "tolls.csv"):
+        if not needed.exists():
+            msg = f"build_highway_networks input missing: {needed}"
+            raise FileNotFoundError(msg)
+
+    _write_dbf(hwy / "tolls.csv", hwy / "tolls.dbf")
+
+    scripts = run_dir / "CTRAMP" / "scripts" / "preprocess"
+    for job in _JOBS:
+        run_cube_job(scripts / job, run_dir, timeout=1800)
+
+    missing = [n for n in _OUTPUTS if not (hwy / n).exists()]
+    if missing:
+        msg = f"Cube jobs finished but outputs are missing from {hwy}: {missing}"
+        raise FileNotFoundError(msg)
+    return None

--- a/src/tm1/steps/build/hsr_trips.py
+++ b/src/tm1/steps/build/hsr_trips.py
@@ -26,7 +26,6 @@ Config::
     build_hsr_trips:
       from: "{reference_run}/INPUT/nonres"
       to: "{run_dir}/nonres"
-      model_year: 2023
       trn_param: "{run_dir}/CTRAMP/scripts/block/trnParam.block"
 
 .. warning:: CUBE-ERA FILE FORMAT, PERMANENT MODEL CONTENT.
@@ -95,7 +94,11 @@ def run(
     step_cfg = step_config(cfg, "build_hsr_trips", kwargs)
     src_dir = resolve_path(step_cfg, cfg, "from", "nonres")
     out_dir = resolve_path(step_cfg, cfg, "to", "nonres")
-    model_year = int(step_cfg["model_year"])
+    # `MODEL_YEAR` describes the run, not this step, so it lives in the project's
+    # `env:` block -- the same place assignment reads it and the Cube jobs get
+    # %MODEL_YEAR% from.  A step key still wins, for direct calls in tests.
+    project_env = cfg.get("env") or {}
+    model_year = int(step_cfg.get("model_year") or project_env["MODEL_YEAR"])
     trn_param = resolve_path(
         step_cfg, cfg, "trn_param", "CTRAMP", "scripts", "block", "trnParam.block"
     )

--- a/src/tm1/steps/build/hsr_trips.py
+++ b/src/tm1/steps/build/hsr_trips.py
@@ -1,0 +1,137 @@
+"""Interpolate high-speed-rail trip tables to the model year (RunModel.bat step 3).
+
+Native replacement for ``HsrTripGeneration.job``.  The California HSR model
+supplies trip tables for 2040 and 2050 only; Travel Model One assumes no HSR
+trips before the opening year and interpolates linearly after it.
+
+The Cube job spreads that over two ``MATRIX`` passes and an intermediate file,
+carrying a slope and intercept scaled by 100 to protect precision::
+
+    m = 100 * (v2050 - v2040) / (2050 - 2040)
+    b = 100 * (v2040 - m * 0.01 * 2040)
+    out = 0.01 * b + m * 0.01 * model_year
+
+The scaling cancels exactly, so this is a plain two-point interpolation, done
+here in one pass with no intermediate ``.tpp``::
+
+    out = v2040 + (v2050 - v2040) * (model_year - 2040) / 10
+
+Everything is zero when the model year precedes 2040, or when
+``HSR_Interregional_Disable`` is set -- a switch ``configure_ctramp`` writes
+into ``trnParam.block``, which is where this step reads it from, so the two
+cannot disagree.
+
+Config::
+
+    build_hsr_trips:
+      from: "{reference_run}/INPUT/nonres"
+      to: "{run_dir}/nonres"
+      model_year: 2023
+      trn_param: "{run_dir}/CTRAMP/scripts/block/trnParam.block"
+
+.. warning:: CUBE-ERA FILE FORMAT, PERMANENT MODEL CONTENT.
+
+    The interpolation is a property of the HSR forecast and outlives Cube; only
+    the ``.tpp`` container is Cube-specific.  When the demand seam moves to OMX,
+    change the reader/writer here, not the arithmetic.
+"""
+
+import logging
+import re
+from pathlib import Path
+
+import numpy as np
+
+from cubeio import read_tpp, write_tpp
+from tm1.project.config import step_config
+from tm1.steps.build import resolve_path
+
+log = logging.getLogger(__name__)
+
+PERIODS: tuple[str, ...] = ("EA", "AM", "MD", "PM", "EV")
+
+#: The two forecast years the California HSR model delivers.
+_BASE_YEAR, _HORIZON_YEAR = 2040, 2050
+
+#: Written table order, matching HsrTripGeneration.job's second MATRIX pass.
+_TABLES: tuple[str, ...] = ("da_veh", "sr2_veh", "taxi_veh", "transit", "walk")
+
+
+def hsr_disabled(trn_param: Path) -> bool:
+    """Read ``HSR_Interregional_Disable`` from ``trnParam.block``.
+
+    Absent means enabled: the Cube job reads the block unconditionally, so a
+    missing switch would have been a Cube error rather than a silent default.
+    """
+    if not trn_param.exists():
+        msg = f"build_hsr_trips: {trn_param} not found (configure_ctramp writes it)"
+        raise FileNotFoundError(msg)
+    match = re.search(
+        r"\nHSR_Interregional_Disable[ \t]*=[ \t]*(\S+)",
+        trn_param.read_text(encoding="utf-8"), flags=re.IGNORECASE,
+    )
+    if match is None:
+        msg = f"build_hsr_trips: HSR_Interregional_Disable not set in {trn_param}"
+        raise ValueError(msg)
+    return int(float(match.group(1))) == 1
+
+
+def interpolate(base: dict, horizon: dict, model_year: int) -> dict[str, np.ndarray]:
+    """Linear two-point interpolation between the 2040 and 2050 tables."""
+    fraction = (model_year - _BASE_YEAR) / (_HORIZON_YEAR - _BASE_YEAR)
+    return {
+        name: base["data"][name]
+        + (horizon["data"][name] - base["data"][name]) * fraction
+        for name in _TABLES
+    }
+
+
+def run(
+    config_dir: Path,  # noqa: ARG001
+    cfg: dict,
+    **kwargs: object,
+) -> str | None:
+    """Write ``nonres/tripsHsr{PERIOD}.tpp`` for the scenario's model year."""
+    step_cfg = step_config(cfg, "build_hsr_trips", kwargs)
+    src_dir = resolve_path(step_cfg, cfg, "from", "nonres")
+    out_dir = resolve_path(step_cfg, cfg, "to", "nonres")
+    model_year = int(step_cfg["model_year"])
+    trn_param = resolve_path(
+        step_cfg, cfg, "trn_param", "CTRAMP", "scripts", "block", "trnParam.block"
+    )
+
+    targets = [out_dir / f"tripsHsr{period}.tpp" for period in PERIODS]
+    if not kwargs.get("force", False) and all(t.exists() for t in targets):
+        log.info("HSR trip tables already built in %s", out_dir)
+        return "skipped"
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    disabled = hsr_disabled(trn_param)
+    before_opening = model_year < _BASE_YEAR
+
+    for period, target in zip(PERIODS, targets, strict=True):
+        base = read_tpp(src_dir / f"tripsHsr{period}_{_BASE_YEAR}.tpp")
+        if disabled or before_opening:
+            zones = base["zones"]
+            tables = {name: np.zeros((zones, zones)) for name in _TABLES}
+        else:
+            horizon = read_tpp(src_dir / f"tripsHsr{period}_{_HORIZON_YEAR}.tpp")
+            if horizon["zones"] != base["zones"]:
+                msg = (
+                    f"tripsHsr{period}: {_BASE_YEAR} has {base['zones']} zones, "
+                    f"{_HORIZON_YEAR} has {horizon['zones']}"
+                )
+                raise ValueError(msg)
+            tables = interpolate(base, horizon, model_year)
+        write_tpp(target, tables, zones=base["zones"])
+
+    why = (
+        "HSR_Interregional_Disable=1" if disabled
+        else f"model year {model_year} precedes the {_BASE_YEAR} opening"
+        if before_opening else None
+    )
+    log.info(
+        "Wrote %d HSR trip tables to %s (%s)", len(targets), out_dir,
+        f"all zero: {why}" if why else f"interpolated to {model_year}",
+    )
+    return None

--- a/src/tm1/steps/build/nonmotorized_skims.py
+++ b/src/tm1/steps/build/nonmotorized_skims.py
@@ -1,0 +1,73 @@
+"""Build the walk/bike distance skims (RunModel.bat step 4).
+
+Two stock Cube jobs, run as-is:
+
+- ``CreateNonMotorizedNetwork.job``  ``hwy/freeflow.net`` -> ``hwy/nonMotorized.net``
+  (flags every non-freeway link walkable/bikeable, plus the explicit bridge
+  allowances; no cluster)
+- ``NonMotorizedSkims.job``  -> ``skims/nonmotskm.tpp`` with DISTWALK / DISTBIKE /
+  DIST tables.  The job hard-codes ``distributeintrastep processid='ctramp',
+  processlist=1-4``, so a 4-node cluster is started around it.
+
+The skim is built once per run — bikes and pedestrians do not congest the
+network, so nothing in the feedback loop ever rewrites it.
+
+Config::
+
+    build_nonmotorized_skims:
+      run_dir: "{run_dir}"
+
+.. warning:: CUBE-ERA IMPLEMENTATION — DELETE WITH CUBE, KEEP THE STEP'S JOB.
+
+    The walk/bike/all-links distance tables are a permanent artifact — the
+    demand models read DISTWALK/DISTBIKE regardless of assignment engine.  The
+    two ``.job`` scripts are not: a non-Cube engine skims shortest-path
+    distance natively in a few lines.  If both engines ever coexist here,
+    follow ``assignment``'s ``backend:`` pattern (same artifact contract, two
+    solvers); otherwise replace this module's body wholesale when Cube goes.
+"""
+
+import logging
+from pathlib import Path
+
+from cube.job import run_cube_job
+from tm1.project.config import step_config
+
+log = logging.getLogger(__name__)
+
+#: NonMotorizedSkims.job distributes over ``processlist = 1-4`` (fixed in the
+#: script), so the cluster must run exactly nodes 1-4.
+_NODES = 4
+
+
+def run(
+    config_dir: Path,  # noqa: ARG001
+    cfg: dict,
+    **kwargs: object,
+) -> str | None:
+    """Build hwy/nonMotorized.net, then skim it to skims/nonmotskm.tpp."""
+    step_cfg = step_config(cfg, "build_nonmotorized_skims", kwargs)
+    run_dir = Path(step_cfg.get("run_dir") or cfg["run_dir"])
+    skim = run_dir / "skims" / "nonmotskm.tpp"
+
+    if not kwargs.get("force", False) and skim.exists():
+        log.info("Non-motorized skims already built: %s", skim)
+        return "skipped"
+
+    freeflow = run_dir / "hwy" / "freeflow.net"
+    if not freeflow.exists():
+        msg = f"build_nonmotorized_skims input missing: {freeflow}"
+        raise FileNotFoundError(msg)
+    (run_dir / "skims").mkdir(parents=True, exist_ok=True)
+
+    scripts = run_dir / "CTRAMP" / "scripts" / "skims"
+    run_cube_job(scripts / "CreateNonMotorizedNetwork.job", run_dir, timeout=1800)
+    run_cube_job(
+        scripts / "NonMotorizedSkims.job", run_dir,
+        cluster_nodes=_NODES, commpath=run_dir / "commpath", timeout=7200,
+    )
+
+    if not skim.exists() or skim.stat().st_size == 0:
+        msg = f"NonMotorizedSkims.job finished but produced no {skim}"
+        raise FileNotFoundError(msg)
+    return None

--- a/src/tm1/steps/build/transit_lines.py
+++ b/src/tm1/steps/build/transit_lines.py
@@ -1,0 +1,101 @@
+r"""Stage the per-period transit line files (RunModel.bat step 4.5).
+
+Native replacement for ``transitDwellAccess.py``'s *Simple* mode, which
+``RunModel.bat`` line 239 runs as::
+
+    transitDwellAccess.py NORMAL NoExtraDelay Simple complexDwell %COMPLEXMODES_DWELL% \\
+                          complexAccess %COMPLEXMODES_ACCESS%
+
+and which needs the NetworkWrangler library.  That dependency is dropped: with
+the shipped configuration the pass does no work on the line data.
+
+**What the legacy pass actually does.**  ``RunModel.bat`` sets both
+``COMPLEXMODES_DWELL`` and ``COMPLEXMODES_ACCESS`` to *empty* (lines 146-147;
+the populated variants on 140-141 are commented out), so Wrangler's
+``addDelay`` runs with no complex dwell or access modes and changes nothing in
+the line file.  The script then writes ``transitOriginal{P}.lin`` once per
+period from the same parsed network, so all five outputs are identical.
+
+Verified against the reference run: its five ``transitOriginal{P}.lin`` are
+byte-identical to each other, and identical to ``INPUT/trn/transitLines.lin``
+across all 33,275 substantive lines.  The only textual residue of Wrangler's
+parse/write round trip is cosmetic and ignored by ``trnbuild``:
+
+- 105 blank lines dropped,
+- the leading ``;###... From: <authoring path>`` comment rewritten to
+  ``;###... From: transitLines.lin``,
+- one provenance comment reflowed onto the end of the preceding data line.
+
+This step therefore copies rather than reconstructing those artefacts: cloning
+a parser's whitespace quirks into new code would be cargo cult, and the
+substantive content is what ``trnbuild`` reads.
+
+.. warning:: THIS STEP IS ONLY VALID WHILE THE COMPLEX DWELL MODES ARE EMPTY.
+
+    ``RunModel.bat`` lines 140-141 carry a commented-out configuration::
+
+        COMPLEXMODES_DWELL=21 24 27 28 30 70 80 81 83 84 87 88
+        COMPLEXMODES_ACCESS=21 24 27 28 30 70 80 81 83 84 87 88 110 120 130
+
+    If anyone enables those, Wrangler applies **real, mode-dependent dwell and
+    access delay** and the five period files stop being copies of the input and
+    of each other.  A plain copy would then silently produce wrong transit
+    running times -- no error, just a different model.  ``dwell_modes`` and
+    ``access_modes`` exist below purely to make that case fail loudly.  If you
+    are here because you set them: the delay logic lives in NetworkWrangler's
+    ``TransitNetwork.addDelay``, and porting it is a project of its own.
+
+Config::
+
+    build_transit_lines:
+      from: "{run_dir}/trn/transitLines.lin"
+      to: "{run_dir}/trn"
+"""
+
+import logging
+import shutil
+from pathlib import Path
+
+from tm1.project.config import step_config
+from tm1.steps.build import resolve_path
+
+log = logging.getLogger(__name__)
+
+PERIODS: tuple[str, ...] = ("EA", "AM", "MD", "PM", "EV")
+
+
+def run(
+    config_dir: Path,  # noqa: ARG001
+    cfg: dict,
+    **kwargs: object,
+) -> str | None:
+    """Write ``transitOriginal{PERIOD}.lin`` for each of the five time periods."""
+    step_cfg = step_config(cfg, "build_transit_lines", kwargs)
+    source = resolve_path(step_cfg, cfg, "from", "trn", "transitLines.lin")
+    out_dir = resolve_path(step_cfg, cfg, "to", "trn")
+
+    # Present so an enabled complex-dwell configuration cannot pass silently.
+    for key in ("dwell_modes", "access_modes"):
+        modes = step_cfg.get(key)
+        if modes:
+            msg = (
+                f"build_transit_lines: {key}={modes!r} requires the mode-dependent "
+                f"dwell/access delay this step does not implement (see the module "
+                f"docstring). Port NetworkWrangler's TransitNetwork.addDelay first."
+            )
+            raise NotImplementedError(msg)
+
+    targets = [out_dir / f"transitOriginal{period}.lin" for period in PERIODS]
+    if not kwargs.get("force", False) and all(t.exists() for t in targets):
+        log.info("Transit line files already staged in %s", out_dir)
+        return "skipped"
+
+    if not source.exists():
+        msg = f"build_transit_lines input missing: {source}"
+        raise FileNotFoundError(msg)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for target in targets:
+        shutil.copy2(source, target)
+    log.info("Wrote %d period line files from %s", len(targets), source.name)
+    return None

--- a/src/tm1/steps/filter_popsyn.py
+++ b/src/tm1/steps/filter_popsyn.py
@@ -1,0 +1,172 @@
+"""Filter unconnected-zone households out of the synthetic population.
+
+Native replacement for two legacy pieces that ran back-to-back under the
+``ITER==1`` guard in ``RunModel.bat``:
+
+- ``model-files/scripts/skims/FindNoAccessZones.job`` — a Cube ``MATRIX`` pass
+  flagging zones whose ``TOLLDISTDA`` skim row is entirely 500000 (Cube's
+  no-path value), written to ``skims/unconnected_zones.csv``.
+- ``model-files/scripts/preprocess/filterUnconnectedHouseholds.py`` (popsyn
+  mode) — read that CSV, dropped households (and their persons) whose home TAZ
+  is unconnected, or byte-copied the files through when nothing was flagged.
+
+Here the zone scan happens in memory via :func:`cubeio.read_tpp` and no
+handoff CSV is written.  A demand model asked to route a household out of a
+zone with no path either crashes or produces garbage, so this runs before the
+demand model ever sees the population; unconnected zones are a network coding
+error and normally number zero, making the copy branch the production path.
+
+Outputs use the canonical names ``hhFile.csv`` / ``personFile.csv`` that
+``simulate_ctramp`` points CT-RAMP's properties at.  The legacy flow instead
+kept the versioned input name (``hhFile.2023_v12.csv``) and had
+``RuntimeConfiguration.py`` discover it; fixing the name at this seam keeps
+the version tag where it belongs, on the ``INPUT/`` side.
+
+Config::
+
+    filter_popsyn:
+      from: "{reference_run}/INPUT/popsyn"   # dir holding hhFile.* + personFile.*
+      to: "{proj_dir}/popsyn"
+      skim: "{proj_dir}/skims/HWYSKMAM.tpp"
+      max_internal_zone: 1454                # zones above this are externals
+"""
+
+import logging
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from cubeio import read_tpp
+from tm1.project.config import step_config
+from tm1.status.slack import notify
+
+log = logging.getLogger(__name__)
+
+#: Cube's no-path cost.  FindNoAccessZones.job tests ``ROWMIN(TOLLDISTDA) == 500000``:
+#: a zone is unconnected only when *every* destination, intrazonal included, is
+#: unreachable by a tolled drive-alone path.
+NO_PATH = 500_000.0
+
+#: The skim table scanned for connectivity.
+_TABLE = "TOLLDISTDA"
+
+#: Source glob -> canonical output name.  Exactly one file must match each glob.
+_FILES: dict[str, str] = {
+    "hhFile.*": "hhFile.csv",
+    "personFile.*": "personFile.csv",
+}
+
+_REQUIRED_KEYS = ("from", "to", "skim", "max_internal_zone")
+
+
+def find_unconnected_zones(skim: Path, max_internal_zone: int) -> list[int]:
+    """Zone numbers (1-based) with no tolled-DA path to any destination.
+
+    Faithful to FindNoAccessZones.job's condition, with the external-zone
+    exclusion filterUnconnectedHouseholds.py applied afterwards folded in:
+    external zones (> *max_internal_zone*) hold no households, so their
+    connectivity is not this step's problem.
+    """
+    mats = read_tpp(skim)
+    if _TABLE not in mats["data"]:
+        msg = f"{skim} has no {_TABLE} table; found {mats['tables']}"
+        raise KeyError(msg)
+    row_min = mats["data"][_TABLE].min(axis=1)
+    flagged = (np.flatnonzero(row_min == NO_PATH) + 1).tolist()
+    internal = [z for z in flagged if z <= max_internal_zone]
+    log.info(
+        "Unconnected zones in %s: %d flagged, %d internal (<= %d)",
+        skim.name, len(flagged), len(internal), max_internal_zone,
+    )
+    return internal
+
+
+def _single_match(src_dir: Path, pattern: str) -> Path:
+    """The one file matching *pattern*, erroring on zero or several candidates."""
+    matches = sorted(p for p in src_dir.glob(pattern) if p.is_file())
+    if len(matches) != 1:
+        found = ", ".join(p.name for p in matches) or "none"
+        msg = f"Expected exactly one {pattern} in {src_dir}; found: {found}"
+        raise FileNotFoundError(msg)
+    return matches[0]
+
+
+def _id_column(df: pd.DataFrame, path: Path) -> str:
+    """The household-ID column name — legacy files spell it HHID or hh_id."""
+    for col in ("HHID", "hh_id"):
+        if col in df.columns:
+            return col
+    msg = f"{path} has neither an HHID nor an hh_id column"
+    raise KeyError(msg)
+
+
+def _filter_files(
+    sources: dict[str, Path], out_dir: Path, unconnected: list[int]
+) -> None:
+    """Drop households home-based in *unconnected* zones from both popsyn files.
+
+    The IDs to drop come from the household file's TAZ column — the person file
+    carries no TAZ, only the household ID linking it back.
+    """
+    hh_path = sources["hhFile.*"]
+    hh = pd.read_csv(hh_path)
+    if "TAZ" not in hh.columns:
+        msg = f"{hh_path} has no TAZ column; cannot locate households"
+        raise KeyError(msg)
+    drop_ids = hh.loc[hh["TAZ"].isin(unconnected), _id_column(hh, hh_path)].unique()
+
+    msg = (
+        f"filter_popsyn: dropping {len(drop_ids)} household(s) in "
+        f"{len(unconnected)} unconnected zone(s): {unconnected}"
+    )
+    log.warning(msg)
+    notify(f":warning: {msg}")
+
+    for pattern, out_name in _FILES.items():
+        df = pd.read_csv(sources[pattern])
+        kept = df.loc[~df[_id_column(df, sources[pattern])].isin(drop_ids)]
+        kept.to_csv(out_dir / out_name, index=False)
+        log.info(
+            "  %s: kept %d of %d rows -> %s",
+            sources[pattern].name, len(kept), len(df), out_name,
+        )
+
+
+def run(
+    config_dir: Path,  # noqa: ARG001
+    cfg: dict,
+    **kwargs: object,
+) -> str | None:
+    """Stage the synthetic population, filtered against network connectivity."""
+    step_cfg = step_config(cfg, "filter_popsyn", kwargs)
+    missing = [k for k in _REQUIRED_KEYS if k not in step_cfg]
+    if missing:
+        msg = f"filter_popsyn config is missing keys: {', '.join(missing)}"
+        raise KeyError(msg)
+
+    src_dir = Path(step_cfg["from"])
+    out_dir = Path(step_cfg["to"])
+    skim = Path(step_cfg["skim"])
+    max_internal_zone = int(step_cfg["max_internal_zone"])
+
+    if not kwargs.get("force", False) and all(
+        (out_dir / name).exists() for name in _FILES.values()
+    ):
+        log.info("Popsyn files already staged in %s", out_dir)
+        return "skipped"
+
+    sources = {pattern: _single_match(src_dir, pattern) for pattern in _FILES}
+    unconnected = find_unconnected_zones(skim, max_internal_zone)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not unconnected:
+        # Byte-copy, not a pandas round-trip: with nothing to filter the staged
+        # files stay identical to INPUT's, keeping them directly diffable.
+        log.info("No unconnected zones -- copying popsyn files through unchanged")
+        for pattern, out_name in _FILES.items():
+            shutil.copy2(sources[pattern], out_dir / out_name)
+    else:
+        _filter_files(sources, out_dir, unconnected)
+    return None

--- a/tests/test_build_highway_networks.py
+++ b/tests/test_build_highway_networks.py
@@ -1,0 +1,87 @@
+"""Tests for build_highway_networks' native csv -> dBASE III conversion.
+
+The Cube jobs themselves are *moved* code (same binary, same scripts) and are
+covered by the run-and-produced checks plus the end-to-end parity run; only the
+rewritten glue -- the DBF writer replacing csvToDbf.py -- needs unit coverage.
+"""
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from tm1.steps.build.highway_networks import _infer_fields, _write_dbf
+
+HEADER_SIZE = 32
+FIELD_SIZE = 32
+
+
+def _read_dbf(path: Path) -> tuple[list[tuple[str, str, int, int]], list[list[str]]]:
+    """Minimal dBASE III parser: ((name, type, length, decimals), records)."""
+    raw = path.read_bytes()
+    n_records, header_size, record_size = struct.unpack_from("<IHH", raw, 4)
+    fields = []
+    for off in range(HEADER_SIZE, header_size - 1, FIELD_SIZE):
+        name, ftype, _, length, decimals = struct.unpack_from("<11scI2B", raw, off)
+        fields.append(
+            (name.rstrip(b"\0").decode(), ftype.decode(), length, decimals)
+        )
+    records = []
+    for i in range(n_records):
+        rec = raw[header_size + i * record_size : header_size + (i + 1) * record_size]
+        assert rec[0:1] == b" "  # not deleted
+        vals, pos = [], 1
+        for _, _, length, _ in fields:
+            vals.append(rec[pos : pos + length].decode())
+            pos += length
+        records.append(vals)
+    return fields, records
+
+
+def test_type_ladder_matches_legacy() -> None:
+    """Ladder is int -> float -> string, with legacy widths and name truncation."""
+    header = ["fac_index", "toll_rate", "facility_name_long", "mixed"]
+    rows = [["2001", "3.5", "Carquinez Bridge", "7"], ["31", "0", "GG", "x2"]]
+    fields = _infer_fields(header, rows)
+    assert fields == [
+        ("FAC_INDEX", "N", 10, 0),
+        ("TOLL_RATE", "N", 10, 5),  # "3.5" fails int() -> float
+        ("FACILITY_N", "C", 18, 0),  # truncated name; longest value + 2
+        ("MIXED", "C", 4, 0),  # "x2" fails float() -> string
+    ]
+
+
+def test_roundtrip_values(tmp_path: Path) -> None:
+    """Written records parse back to the csv's values."""
+    src = tmp_path / "tolls.csv"
+    src.write_text(
+        "facility_name,fac_index,use,tollam_da\n"
+        "Carquinez Bridge GP,2001,1,3.5\n"
+        "SFOBB,2005,1,7\n"
+    )
+    n_rows, fac_index = 2, 2001
+    out = tmp_path / "tolls.dbf"
+    assert _write_dbf(src, out) == n_rows
+
+    fields, records = _read_dbf(out)
+    assert [f[0] for f in fields] == ["FACILITY_N", "FAC_INDEX", "USE", "TOLLAM_DA"]
+    assert records[0][0].strip() == "Carquinez Bridge GP"
+    assert int(records[0][1]) == fac_index
+    assert float(records[0][3]) == pytest.approx(3.5)
+    assert float(records[1][3]) == pytest.approx(7.0)
+
+
+def test_value_too_wide_errors(tmp_path: Path) -> None:
+    """A numeric that cannot fit its fixed width fails loudly, not truncated."""
+    src = tmp_path / "bad.csv"
+    src.write_text("v\n123456789012345\n")  # 15 digits > N(10)
+    with pytest.raises(ValueError, match="does not fit"):
+        _write_dbf(src, tmp_path / "bad.dbf")
+
+
+def test_duplicate_truncated_names_error(tmp_path: Path) -> None:
+    """Two columns that collide at 10 characters are an error, not silent loss."""
+    src = tmp_path / "dup.csv"
+    src.write_text("facility_name_a,facility_name_b\n1,2\n")
+    with pytest.raises(ValueError, match="collides"):
+        _write_dbf(src, tmp_path / "dup.dbf")

--- a/tests/test_build_transit_hsr.py
+++ b/tests/test_build_transit_hsr.py
@@ -1,0 +1,181 @@
+"""Tests for the slice D build steps: transit line staging and HSR interpolation.
+
+The reference run only exercises the trivial branch of each -- its complex
+dwell modes are empty and its model year precedes the HSR opening -- so the
+interesting behaviour is covered here with synthetic inputs.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cubeio import read_tpp, write_tpp
+from tm1.steps.build import hsr_trips, transit_lines
+
+ZONES = 4
+PERIODS = ("EA", "AM", "MD", "PM", "EV")
+
+
+# --------------------------------------------------------------------------
+# build_transit_lines
+# --------------------------------------------------------------------------
+
+
+def _cfg_lines(src: Path, out: Path, **extra: object) -> dict:
+    return {"steps": {"build_transit_lines": {"from": str(src), "to": str(out), **extra}}}
+
+
+def test_writes_one_identical_file_per_period(tmp_path: Path) -> None:
+    """All five period files are copies of the master line file."""
+    src = tmp_path / "transitLines.lin"
+    src.write_text('LINE NAME="30_7AC",\n    FREQ[2]=32.0,\n N= 2412,\n')
+    out = tmp_path / "trn"
+
+    assert transit_lines.run(tmp_path, _cfg_lines(src, out)) is None
+    written = sorted(out.glob("transitOriginal*.lin"))
+    assert len(written) == len(PERIODS)
+    for path in written:
+        assert path.read_bytes() == src.read_bytes()
+
+
+def test_complex_dwell_modes_refuse_to_run(tmp_path: Path) -> None:
+    """Enabling complex dwell must fail loudly, not silently copy.
+
+    With dwell modes set, the legacy applies mode-dependent delay and the five
+    files stop being copies; a silent copy would change transit running times
+    with no error.
+    """
+    src = tmp_path / "transitLines.lin"
+    src.write_text("LINE NAME=x\n")
+    out = tmp_path / "trn"
+
+    with pytest.raises(NotImplementedError, match="dwell_modes"):
+        transit_lines.run(tmp_path, _cfg_lines(src, out, dwell_modes=[21, 24]))
+    with pytest.raises(NotImplementedError, match="access_modes"):
+        transit_lines.run(tmp_path, _cfg_lines(src, out, access_modes=[110]))
+    assert not out.exists() or not list(out.glob("*.lin"))
+
+
+def test_transit_lines_skip_and_force(tmp_path: Path) -> None:
+    """Existing outputs are left alone unless force is passed."""
+    src = tmp_path / "transitLines.lin"
+    src.write_text("LINE NAME=x\n")
+    out = tmp_path / "trn"
+    transit_lines.run(tmp_path, _cfg_lines(src, out))
+
+    src.write_text("LINE NAME=changed\n")
+    assert transit_lines.run(tmp_path, _cfg_lines(src, out)) == "skipped"
+    assert "changed" not in (out / "transitOriginalAM.lin").read_text()
+
+    transit_lines.run(tmp_path, _cfg_lines(src, out), force=True)
+    assert "changed" in (out / "transitOriginalAM.lin").read_text()
+
+
+def test_transit_lines_missing_source_errors(tmp_path: Path) -> None:
+    """A missing master line file is a hard stop."""
+    with pytest.raises(FileNotFoundError, match="input missing"):
+        transit_lines.run(
+            tmp_path, _cfg_lines(tmp_path / "absent.lin", tmp_path / "trn")
+        )
+
+
+# --------------------------------------------------------------------------
+# build_hsr_trips
+# --------------------------------------------------------------------------
+
+
+def _write_hsr_inputs(src: Path, base: float, horizon: float) -> None:
+    """Per-period 2040/2050 tables, every cell of every table a constant."""
+    src.mkdir(parents=True, exist_ok=True)
+    for period in PERIODS:
+        for year, value in ((2040, base), (2050, horizon)):
+            write_tpp(
+                src / f"tripsHsr{period}_{year}.tpp",
+                {n: np.full((ZONES, ZONES), value) for n in hsr_trips._TABLES},  # noqa: SLF001
+            )
+
+
+def _trn_param(tmp_path: Path, disable: int) -> Path:
+    p = tmp_path / "trnParam.block"
+    p.write_text(f"; block\nMeans_Based_Fare_Factor = 0.50\n"
+                 f"HSR_Interregional_Disable  = {disable}\n")
+    return p
+
+
+def _cfg_hsr(src: Path, out: Path, trn: Path, year: int) -> dict:
+    return {"steps": {"build_hsr_trips": {
+        "from": str(src), "to": str(out), "trn_param": str(trn), "model_year": year,
+    }}}
+
+
+def test_hsr_interpolates_between_forecast_years(tmp_path: Path) -> None:
+    """2045 sits halfway between the 2040 and 2050 tables."""
+    src, out = tmp_path / "in", tmp_path / "nonres"
+    _write_hsr_inputs(src, 100.0, 200.0)
+    hsr_trips.run(tmp_path, _cfg_hsr(src, out, _trn_param(tmp_path, 0), 2045))
+
+    data = read_tpp(out / "tripsHsrAM.tpp")
+    assert data["tables"] == list(hsr_trips._TABLES)  # noqa: SLF001
+    for name in hsr_trips._TABLES:  # noqa: SLF001
+        assert np.allclose(data["data"][name], 150.0)
+
+
+def test_hsr_extrapolates_beyond_horizon(tmp_path: Path) -> None:
+    """The legacy formula is a line, not a clamp: 2060 continues the slope."""
+    src, out = tmp_path / "in", tmp_path / "nonres"
+    _write_hsr_inputs(src, 100.0, 200.0)
+    hsr_trips.run(tmp_path, _cfg_hsr(src, out, _trn_param(tmp_path, 0), 2060))
+    assert np.allclose(read_tpp(out / "tripsHsrAM.tpp")["data"]["da_veh"], 300.0)
+
+
+def test_hsr_zero_before_opening_year(tmp_path: Path) -> None:
+    """No HSR trips before 2040 -- the 2023 base case."""
+    src, out = tmp_path / "in", tmp_path / "nonres"
+    _write_hsr_inputs(src, 100.0, 200.0)
+    hsr_trips.run(tmp_path, _cfg_hsr(src, out, _trn_param(tmp_path, 0), 2023))
+
+    for period in PERIODS:
+        data = read_tpp(out / f"tripsHsr{period}.tpp")
+        for name in hsr_trips._TABLES:  # noqa: SLF001
+            assert not data["data"][name].any()
+
+
+def test_hsr_disable_switch_zeroes_output(tmp_path: Path) -> None:
+    """HSR_Interregional_Disable=1 wins even in a year past the opening."""
+    src, out = tmp_path / "in", tmp_path / "nonres"
+    _write_hsr_inputs(src, 100.0, 200.0)
+    hsr_trips.run(tmp_path, _cfg_hsr(src, out, _trn_param(tmp_path, 1), 2050))
+    assert not read_tpp(out / "tripsHsrAM.tpp")["data"]["da_veh"].any()
+
+
+def test_hsr_disabled_reads_trn_param(tmp_path: Path) -> None:
+    """The switch is read from trnParam.block, which configure_ctramp writes."""
+    assert hsr_trips.hsr_disabled(_trn_param(tmp_path, 1)) is True
+    assert hsr_trips.hsr_disabled(_trn_param(tmp_path, 0)) is False
+
+
+def test_hsr_missing_switch_errors(tmp_path: Path) -> None:
+    """A trnParam.block without the switch is an error, not a default."""
+    p = tmp_path / "trnParam.block"
+    p.write_text("; block\nMeans_Based_Fare_Factor = 0.50\n")
+    with pytest.raises(ValueError, match="HSR_Interregional_Disable"):
+        hsr_trips.hsr_disabled(p)
+
+
+def test_hsr_missing_trn_param_errors(tmp_path: Path) -> None:
+    """A missing trnParam.block names configure_ctramp as the producer."""
+    with pytest.raises(FileNotFoundError, match="configure_ctramp"):
+        hsr_trips.hsr_disabled(tmp_path / "absent.block")
+
+
+def test_hsr_zone_mismatch_errors(tmp_path: Path) -> None:
+    """Forecast tables that disagree on zone count must not be interpolated."""
+    src, out = tmp_path / "in", tmp_path / "nonres"
+    _write_hsr_inputs(src, 100.0, 200.0)
+    write_tpp(
+        src / "tripsHsrEA_2050.tpp",
+        {n: np.full((ZONES + 1, ZONES + 1), 200.0) for n in hsr_trips._TABLES},  # noqa: SLF001
+    )
+    with pytest.raises(ValueError, match="zones"):
+        hsr_trips.run(tmp_path, _cfg_hsr(src, out, _trn_param(tmp_path, 0), 2045))

--- a/tests/test_filter_popsyn.py
+++ b/tests/test_filter_popsyn.py
@@ -1,0 +1,152 @@
+"""Tests for the filter_popsyn step.
+
+The reference run has *zero* unconnected zones, so an end-to-end comparison
+against it only ever exercises the copy branch.  The filter branch is covered
+here instead, with a synthetic skim whose disconnected zones are known.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from cubeio import write_tpp
+from tm1.steps import filter_popsyn
+
+ZONES = 5
+#: Zones 1..4 internal, zone 5 external (mirrors the real 1454/1455 split).
+MAX_INTERNAL = 4
+#: One household per zone, numbered so household HHID_BASE+z lives in zone z.
+HHID_BASE = 100
+PERSONS_PER_HH = 2
+
+
+def _write_skim(path: Path, unconnected: tuple[int, ...] = ()) -> None:
+    """A TOLLDISTDA skim where each zone in *unconnected* has an all-500000 row."""
+    dist = np.full((ZONES, ZONES), 12.34)
+    for zone in unconnected:
+        dist[zone - 1, :] = filter_popsyn.NO_PATH
+    write_tpp(path, {"TOLLDISTDA": dist})
+
+
+def _write_popsyn(src_dir: Path, person_id_col: str = "HHID") -> None:
+    """Versioned popsyn files: one household per zone, two persons each."""
+    src_dir.mkdir(parents=True, exist_ok=True)
+    hh = pd.DataFrame(
+        {"HHID": [HHID_BASE + z for z in range(1, ZONES + 1)],
+         "TAZ": range(1, ZONES + 1)}
+    )
+    hh.to_csv(src_dir / "hhFile.2023_v12.csv", index=False)
+    persons = pd.DataFrame(
+        {
+            person_id_col: np.repeat(hh["HHID"].to_numpy(), PERSONS_PER_HH),
+            "PERID": range(1, PERSONS_PER_HH * ZONES + 1),
+        }
+    )
+    persons.to_csv(src_dir / "personFile.2023_v12.csv", index=False)
+
+
+def _cfg(src_dir: Path, out_dir: Path, skim: Path) -> dict:
+    return {
+        "steps": {
+            "filter_popsyn": {
+                "from": str(src_dir),
+                "to": str(out_dir),
+                "skim": str(skim),
+                "max_internal_zone": MAX_INTERNAL,
+            }
+        }
+    }
+
+
+def test_find_unconnected_zones_excludes_externals(tmp_path: Path) -> None:
+    """Zone 5 is also unconnected but external, so only zone 3 is reported."""
+    skim = tmp_path / "HWYSKMAM.tpp"
+    _write_skim(skim, unconnected=(3, 5))
+    assert filter_popsyn.find_unconnected_zones(skim, MAX_INTERNAL) == [3]
+
+
+def test_find_unconnected_zones_all_connected(tmp_path: Path) -> None:
+    """A fully connected skim yields no unconnected zones."""
+    skim = tmp_path / "HWYSKMAM.tpp"
+    _write_skim(skim)
+    assert filter_popsyn.find_unconnected_zones(skim, MAX_INTERNAL) == []
+
+
+def test_copy_branch_is_byte_exact(tmp_path: Path) -> None:
+    """With nothing to filter, outputs are byte copies -- not a pandas round-trip."""
+    src, out, skim = tmp_path / "INPUT", tmp_path / "popsyn", tmp_path / "skim.tpp"
+    src.mkdir()
+    # Formatting pandas would not preserve: CRLF line endings, a quoted field.
+    raw = b'HHID,TAZ,NAME\r\n101,1,"a,b"\r\n102,2,plain\r\n'
+    (src / "hhFile.2023_v12.csv").write_bytes(raw)
+    (src / "personFile.2023_v12.csv").write_bytes(b"HHID,PERID\r\n101,1\r\n")
+    _write_skim(skim)
+
+    assert filter_popsyn.run(tmp_path, _cfg(src, out, skim)) is None
+    assert (out / "hhFile.csv").read_bytes() == raw
+    assert (out / "personFile.csv").read_bytes() == b"HHID,PERID\r\n101,1\r\n"
+
+
+def test_filter_branch_drops_unconnected_households(tmp_path: Path) -> None:
+    """Households in internal-unconnected zones vanish from both files."""
+    src, out, skim = tmp_path / "INPUT", tmp_path / "popsyn", tmp_path / "skim.tpp"
+    _write_popsyn(src)
+    # Zone 3 internal-unconnected -> filtered; zone 5 unconnected but external -> kept.
+    _write_skim(skim, unconnected=(3, 5))
+
+    assert filter_popsyn.run(tmp_path, _cfg(src, out, skim)) is None
+
+    hh = pd.read_csv(out / "hhFile.csv")
+    assert hh["TAZ"].tolist() == [1, 2, 4, 5]
+    persons = pd.read_csv(out / "personFile.csv")
+    assert HHID_BASE + 3 not in persons["HHID"].to_numpy()
+    assert len(persons) == PERSONS_PER_HH * (ZONES - 1)
+
+
+def test_filter_branch_hh_id_spelling(tmp_path: Path) -> None:
+    """Person files spelling the ID column hh_id are filtered the same way."""
+    src, out, skim = tmp_path / "INPUT", tmp_path / "popsyn", tmp_path / "skim.tpp"
+    _write_popsyn(src, person_id_col="hh_id")
+    _write_skim(skim, unconnected=(3,))
+
+    filter_popsyn.run(tmp_path, _cfg(src, out, skim))
+    persons = pd.read_csv(out / "personFile.csv")
+    assert HHID_BASE + 3 not in persons["hh_id"].to_numpy()
+    assert len(persons) == PERSONS_PER_HH * (ZONES - 1)
+
+
+def test_skips_when_outputs_exist(tmp_path: Path) -> None:
+    """Existing outputs are left alone unless force is passed."""
+    src, out, skim = tmp_path / "INPUT", tmp_path / "popsyn", tmp_path / "skim.tpp"
+    _write_popsyn(src)
+    _write_skim(skim)
+    out.mkdir()
+    (out / "hhFile.csv").write_text("stale")
+    (out / "personFile.csv").write_text("stale")
+
+    assert filter_popsyn.run(tmp_path, _cfg(src, out, skim)) == "skipped"
+    assert (out / "hhFile.csv").read_text() == "stale"
+
+    filter_popsyn.run(tmp_path, _cfg(src, out, skim), force=True)
+    assert (out / "hhFile.csv").read_text() != "stale"
+
+
+def test_ambiguous_source_glob_errors(tmp_path: Path) -> None:
+    """Two hhFile.* candidates is a loud error, never a silent pick."""
+    src, out, skim = tmp_path / "INPUT", tmp_path / "popsyn", tmp_path / "skim.tpp"
+    _write_popsyn(src)
+    (src / "hhFile.older.csv").write_text("HHID,TAZ\n")
+    _write_skim(skim)
+
+    with pytest.raises(FileNotFoundError, match="exactly one hhFile"):
+        filter_popsyn.run(tmp_path, _cfg(src, out, skim))
+
+
+def test_missing_config_keys_error(tmp_path: Path) -> None:
+    """Every absent required config key is named in one error."""
+    with pytest.raises(KeyError, match="skim, max_internal_zone"):
+        filter_popsyn.run(
+            tmp_path, {"steps": {"filter_popsyn": {"from": "x", "to": "y"}}}
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -127,15 +127,6 @@ toml = [
 ]
 
 [[package]]
-name = "dbfpy3"
-version = "4.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/0f/6fa5f0898fb000a4331a333cf0bed385135d8f33324a71e9b21f266cc181/dbfpy3-4.2.3.tar.gz", hash = "sha256:25c2033c9c909911542e8421a039ee7b049e7fa90ce73b23a2035c1cfd43eff4", size = 27210, upload-time = "2025-08-30T15:07:05.899Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/73/c85bd126149d44a43dbf8ff48b42f1177817436ceadb76a4c9f8a925291f/dbfpy3-4.2.3-py2.py3-none-any.whl", hash = "sha256:6b273649643542ba0f60d0e14fdc8d675580f3675e7d1663d861fc99d675cd78", size = 21844, upload-time = "2025-08-30T15:07:04.706Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -280,18 +271,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/1f/8c66ef982a01ae4cbdabba679a2bc711f262cedf23bfb9682293146f8a98/ndindex-1.10.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae73cd2d66b09ef2f2a7d7f93bad396d6abf168d1ee825e403c6c5fb8ae1341c", size = 1543876, upload-time = "2025-11-19T20:38:37.456Z" },
     { url = "https://files.pythonhosted.org/packages/05/a1/7c7e3a3c6e81b4284fd0d53cbaec51d9e5b90df26dd78e9bde06cb307217/ndindex-1.10.1-cp311-cp311-win32.whl", hash = "sha256:890bb92f0a779e6f16bdbcc8bd2e06c32bcc0239e5893ba246114eb924aecaaa", size = 149149, upload-time = "2025-11-19T20:38:38.911Z" },
     { url = "https://files.pythonhosted.org/packages/3b/38/99e1fb0effdef74b883be615ea0053ebcea28a53fd8b896263f4e99b0113/ndindex-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:1827a40301405b44ad709e388c5b48cf35cd90a67f77e63f0f17d87f6000fa81", size = 157246, upload-time = "2025-11-19T20:38:40.197Z" },
-]
-
-[[package]]
-name = "networkwrangler"
-version = "1.5"
-source = { git = "https://github.com/BayAreaMetro/NetworkWrangler?rev=c806951496126c6c5a3a37f5c325176aee91f31d#c806951496126c6c5a3a37f5c325176aee91f31d" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "pywin32" },
-    { name = "simpleparse" },
-    { name = "xlrd" },
 ]
 
 [[package]]
@@ -592,16 +571,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pywin32"
-version = "311"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
-    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -669,16 +638,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
-]
-
-[[package]]
-name = "simpleparse"
-version = "2.2.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/79/e3/54760b15d16a986a819408d2ba4f831ed1e47a25f7b0e39cfc8b3f8dcbfd/SimpleParse-2.2.4.tar.gz", hash = "sha256:892b2ef7cd182bef9197d9d47622978a7ff63e488bc1296e842a7f1f2d76fea6", size = 186285, upload-time = "2023-03-11T21:16:37.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/e5/31e56019d589e94c99f54324f4307a2df876d4715172a6de6c5480ffdecc/SimpleParse-2.2.4-cp311-cp311-win32.whl", hash = "sha256:22a1b4ab25c84f5c9da8e5162bf55f7ba49dbf018772c3f6f636cfd98ebd0dce", size = 240609, upload-time = "2023-03-11T21:16:16.366Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a7/0cf1d4e3d52dbf38db0a98b3f5ecc0da55addab86a526c657f0804b9bb77/SimpleParse-2.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:55bc695fdcf461965957af9556136350100b421e7a1a62bda5242c1a94a9a001", size = 245057, upload-time = "2023-03-11T21:16:18.369Z" },
 ]
 
 [[package]]
@@ -753,8 +712,6 @@ dependencies = [
 
 [package.optional-dependencies]
 legacy = [
-    { name = "dbfpy3" },
-    { name = "networkwrangler" },
     { name = "xlrd" },
     { name = "xlutils" },
     { name = "xlwt" },
@@ -770,8 +727,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dbfpy3", marker = "extra == 'legacy'", specifier = ">=2.3" },
-    { name = "networkwrangler", marker = "extra == 'legacy'", git = "https://github.com/BayAreaMetro/NetworkWrangler?rev=c806951496126c6c5a3a37f5c325176aee91f31d" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openmatrix", specifier = ">=0.3.5" },
     { name = "pandas", specifier = ">=2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -127,15 +127,6 @@ toml = [
 ]
 
 [[package]]
-name = "dbfpy3"
-version = "4.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/0f/6fa5f0898fb000a4331a333cf0bed385135d8f33324a71e9b21f266cc181/dbfpy3-4.2.3.tar.gz", hash = "sha256:25c2033c9c909911542e8421a039ee7b049e7fa90ce73b23a2035c1cfd43eff4", size = 27210, upload-time = "2025-08-30T15:07:05.899Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/73/c85bd126149d44a43dbf8ff48b42f1177817436ceadb76a4c9f8a925291f/dbfpy3-4.2.3-py2.py3-none-any.whl", hash = "sha256:6b273649643542ba0f60d0e14fdc8d675580f3675e7d1663d861fc99d675cd78", size = 21844, upload-time = "2025-08-30T15:07:04.706Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -280,18 +271,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/1f/8c66ef982a01ae4cbdabba679a2bc711f262cedf23bfb9682293146f8a98/ndindex-1.10.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae73cd2d66b09ef2f2a7d7f93bad396d6abf168d1ee825e403c6c5fb8ae1341c", size = 1543876, upload-time = "2025-11-19T20:38:37.456Z" },
     { url = "https://files.pythonhosted.org/packages/05/a1/7c7e3a3c6e81b4284fd0d53cbaec51d9e5b90df26dd78e9bde06cb307217/ndindex-1.10.1-cp311-cp311-win32.whl", hash = "sha256:890bb92f0a779e6f16bdbcc8bd2e06c32bcc0239e5893ba246114eb924aecaaa", size = 149149, upload-time = "2025-11-19T20:38:38.911Z" },
     { url = "https://files.pythonhosted.org/packages/3b/38/99e1fb0effdef74b883be615ea0053ebcea28a53fd8b896263f4e99b0113/ndindex-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:1827a40301405b44ad709e388c5b48cf35cd90a67f77e63f0f17d87f6000fa81", size = 157246, upload-time = "2025-11-19T20:38:40.197Z" },
-]
-
-[[package]]
-name = "networkwrangler"
-version = "1.5"
-source = { git = "https://github.com/BayAreaMetro/NetworkWrangler?rev=c806951496126c6c5a3a37f5c325176aee91f31d#c806951496126c6c5a3a37f5c325176aee91f31d" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "pywin32" },
-    { name = "simpleparse" },
-    { name = "xlrd" },
 ]
 
 [[package]]
@@ -592,16 +571,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pywin32"
-version = "311"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
-    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -672,16 +641,6 @@ wheels = [
 ]
 
 [[package]]
-name = "simpleparse"
-version = "2.2.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/79/e3/54760b15d16a986a819408d2ba4f831ed1e47a25f7b0e39cfc8b3f8dcbfd/SimpleParse-2.2.4.tar.gz", hash = "sha256:892b2ef7cd182bef9197d9d47622978a7ff63e488bc1296e842a7f1f2d76fea6", size = 186285, upload-time = "2023-03-11T21:16:37.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/e5/31e56019d589e94c99f54324f4307a2df876d4715172a6de6c5480ffdecc/SimpleParse-2.2.4-cp311-cp311-win32.whl", hash = "sha256:22a1b4ab25c84f5c9da8e5162bf55f7ba49dbf018772c3f6f636cfd98ebd0dce", size = 240609, upload-time = "2023-03-11T21:16:16.366Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a7/0cf1d4e3d52dbf38db0a98b3f5ecc0da55addab86a526c657f0804b9bb77/SimpleParse-2.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:55bc695fdcf461965957af9556136350100b421e7a1a62bda5242c1a94a9a001", size = 245057, upload-time = "2023-03-11T21:16:18.369Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -742,8 +701,6 @@ name = "travel-model-one"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "dbfpy3" },
-    { name = "networkwrangler" },
     { name = "numpy" },
     { name = "openmatrix" },
     { name = "pandas" },
@@ -766,8 +723,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dbfpy3", specifier = ">=2.3" },
-    { name = "networkwrangler", git = "https://github.com/BayAreaMetro/NetworkWrangler?rev=c806951496126c6c5a3a37f5c325176aee91f31d" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openmatrix", specifier = ">=0.3.5" },
     { name = "pandas", specifier = ">=2.0" },


### PR DESCRIPTION
> **Core phase 3 of 4** — Travel Model One to Python migration.
>
> The **core phases are sequential**: each builds on the one before, and merge order is
> #103 → #104 → #115 → #116. Nothing changes what runs in
> production: CT-RAMP + Cube remain the production stack until each later phase passes
> its own gate.
>
> | # | Core phase | PR | Scope | Files |
> |---|---|---|---|---|
> | 1 | Runtime harness | #103 | `tm1` CLI, projects + cases, CT-RAMP headless, Cube launcher — and full `RunModel.bat` parity | 66 |
> | 2 | cubeio | #104 | pure-Python Cube matrix and network I/O, bit-exact tests | 39 |
> | 3 | Streamlining ← **this PR** | #115 | the legacy `.job`/`.py` glue replaced with native Python, using #104 | 16 |
> | 4 | ActivitySim | #116 | the demand engine, and nothing else | 244 |
>
> **Sidebars** hang off the spine and block nothing. They are queued behind their base,
> not behind each other:
>
> | Sidebar | PR | Sits on | Scope | Files |
> |---|---|---|---|---|
> | Calibration reporting | #117 | #104 | HTML survey-vs-model report | 38 |
> | AequilibraE backend | #118 | phase 4 | a candidate assignment engine, evaluated — not adopted | 33 |
> | Multi-machine claiming | #119 | #103 | scope only, no code | 1 |
>
> **Each core phase moves exactly one piece.** Demand and assignment are the two moving
> parts; every phase changes one of them and holds the other fixed, so each can be
> validated against the one before it:
>
> | Phase | Demand | Assignment | What actually changes |
> |---|---|---|---|
> | 1 | CT-RAMP | Cube | orchestration — the whole of `RunModel.bat`, run from config |
> | 2 | CT-RAMP | Cube | matrix and network I/O — no model change |
> | 3 | CT-RAMP | Cube | the preprocessing glue moves to Python |
> | 4 | **ActivitySim** | Cube | the demand engine, and nothing else |
>
> The combination deliberately never built is CT-RAMP + a new assignment engine.
> Whichever engine eventually replaces Cube exists to serve ActivitySim, and CT-RAMP and
> Cube retire together — which is what keeps this a diagonal rather than a grid, and why
> the demand/assignment seam needs one modern format plus one legacy adapter rather than
> every engine speaking to every other.
>
> **Which engine replaces Cube is not decided.** The AequilibraE sidebar evaluates a
> candidate and does not adopt it; Cube remains the assignment engine until one is chosen
> and validated. Nothing in the core phases depends on that choice — the `backend:` key
> exists precisely so it stays a late decision.
>
> **Parity lives in phase 1, not later.** The harness reproduces the legacy run from
> pristine `INPUT/` before anything is swapped, because an ActivitySim-vs-CT-RAMP
> comparison made through an unproven harness cannot separate a demand-model difference
> from a harness difference. Streamlining then sits between parity and the demand swap so
> the two rewrites do not overlap: replace the glue while the model is still CT-RAMP, then
> replace the model while the glue is already Python.
>
> **This is deliberately not a like-for-like port.** Parts of the legacy pipeline bridge
> its toolchain rather than model anything. The clearest case: `.tpp` matrices could only
> be read by Cube, so data was exported to CSV and passed between Cube, R and batch. Given
> the tools available that was a sound design — but re-implementing it in Python would
> carry the cost forward without the constraint that motivated it.
>
> About **10 GB of every 53 GB run is derived or duplicated data**:
>
> | Artifact | Size | Why it exists | How it goes away |
> |---|---|---|---|
> | `database/*SkimsDatabase*.csv` | 4.4 GB | exports `.tpp` skims to CSV for R and Python | **#104** — read `.tpp` natively |
> | `updated_output/*.rdata` | 1.0 GB | R re-serialisation of data already in CSV | **#104** — no Cube→CSV→R hop |
> | `main/indivTripDataIncome_3.csv` | 1.6 GB | rewrites a 1.5 GB trip table to add one column | join at read time |
> | `extractor/` | 2.2 GB | a subset staged as a folder so it can be copied to `M:` | ship a manifest, or write direct |
> | `INPUT/` copied into working dirs | 0.6 GB | keeps pristine inputs by duplicating them | read in place |
>
> The first two — **5.4 GB per run, plus a Cube job and an entire toolchain hop** — are
> unlocked by the `.tpp` reader in **#104**. The rest are retired as phase 3 ports the
> steps around them. So parity means *equivalent results*, not an equivalent file layout.
> Detail: [Port the intent, not the mechanism](https://github.com/BayAreaMetro/travel-model-one/blob/phase-4-model-parity/MIGRATION_NOTES.md#port-the-intent-not-the-mechanism).
>
> Legacy housekeeping, documentation and network enhancements are not yet scoped.
> Full plan: [`MIGRATION_NOTES.md`](https://github.com/BayAreaMetro/travel-model-one/blob/phase-4-model-parity/MIGRATION_NOTES.md).

---

### Goal

Replace the legacy preprocessing glue — five `.job` files and two `.py` scripts that
`RunModel.bat` shelled out to — with native Python steps, now that #104 can read and
write Cube's formats without Cube.

The Cube jobs that actually *model* something still run unmodified, through `runtpp`,
exactly as before. What goes away is the code that only existed to move data between
tools: a CSV-to-DBF converter, a `.lin` demultiplexer, a matrix interpolation done in
a `.job` because nothing else could open a `.tpp`.

**Nothing about the model changes.** Same networks, same skims, same population, same
Cube engine. The verification for each port is an output diff against the legacy
script's own output, listed below.

### What each legacy piece became

| Was | Now | How it is verified |
|---|---|---|
| `FindNoAccessZones.job` + `filterUnconnectedHouseholds.py` | `filter_popsyn` | outputs **byte-identical** to the reference run's `popsyn/*.csv`; 0 unconnected zones (the healthy case), so the INPUT files copy through unchanged. The filter branch is covered by synthetic-skim tests |
| `csvToDbf.py` | native DBF writer inside `build_highway_networks` | `tolls.dbf` — **42 field specs and 2,478 values identical** to the legacy output |
| `SetTolls.job`, `SetHovXferPenalties.job`, `CreateFiveHighwayNetworks.job` | `build_highway_networks` (moved, not rewritten) | stock jobs run as-is through `runtpp` |
| `CreateNonMotorizedNetwork.job`, `NonMotorizedSkims.job` | `build_nonmotorized_skims` (moved) | `nonmotskm.tpp` **100% cell-exact** vs the reference run |
| `transitDwellAccess.py` (Simple mode) | `build_transit_lines` | native `.lin` demux; with `COMPLEXMODES_DWELL/ACCESS` empty, as `RunModel.bat` ships them, the pass leaves line data untouched |
| `HsrTripGeneration.job` | `build_hsr_trips` | cubeio interpolation of the California HSR 2040/2050 tables; all-zero before the 2040 opening year, so zero for 2023 |

**Verification effort follows fate.** Rewritten code gets an output diff against the
legacy artifact. Moved code — same binary, same script, same inputs — needs only
ran-and-produced. `docs/legacy_crosswalk.md` on this branch maps every piece of
`RunModel.bat` / `RunIteration.bat` to one of five fates and is the review contract.

### The payoff: two dependencies retire

```
-    "dbfpy3>=2.3",
-    "NetworkWrangler @ git+https://github.com/BayAreaMetro/NetworkWrangler@c806951...",
```

`dbfpy3` existed only for `csvToDbf.py`. `NetworkWrangler` existed only for
`transitDwellAccess.py` — and brought `simpleparse` and `pywin32` with it. Both are
gone, along with the install step where a new machine had to clone NetworkWrangler
because its `setup.py` omitted a directory it imports at module level.

What remains in the `legacy` extra is `xlrd`/`xlutils`/`xlwt`, for the CT-RAMP UEC
`.xls` workbooks. That empties out with the demand swap, not here.

### Two fixes that came out of the port

**`Ctrl-C` during a Cube job left the cluster running.** Cancelling reached the Python
process but never the cluster nodes — `cmd` or the scheduled task started them, so a
48-node job left 49 orphans holding licence leases, and the bat file's
`Cluster ... Close Exit` line never ran either. The execution paths move into
`_execute_job` so cancellation has exactly one place to catch.

**`build_hsr_trips` had its own `model_year:` key.** A case overriding `env.MODEL_YEAR`
to 2035 would have left HSR trips interpolated to 2023. It now reads the project's
`env:` block, the same place assignment reads it and the Cube jobs get `%MODEL_YEAR%`
from.

### How to review

Start with `docs/legacy_crosswalk.md` — it is the map. Then
`projects/ctramp_2023/config.yaml`, where six legacy step declarations became two
native ones; the diff there is the clearest statement of what this PR does.

The step modules are small and each one names the script it replaces in its docstring.
`build_highway_networks._write_dbf` is the only piece doing something subtle (the DBF
field widths are transcribed from `csvToDbf.py`'s choices, not re-derived).

### Testing

339 tests pass. Lint is at the phase-1 baseline of 6 errors, all pre-existing in
`simulate_ctramp.py`.

### Status

Draft, and staying that way until #103 and #104 merge — the conventions this builds on
are still under review there. The code is complete and each port is verified against
its legacy output; what it is waiting for is its base, not more work.
